### PR TITLE
feat: ship improvements plan items 4-10, 12-13 + ebec + Standard Schema

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1,28 +1,30 @@
 # Architecture
 
-Validup's model has three nouns — **Container**, **Validator**, **Issue** — and one verb: `Container.run(data)`. Integration packages either produce a `Validator` from a foreign validation library (`@validup/zod`, `@validup/express-validator`) or wire a `Container` into a runtime / framework (`@validup/routup`, `@validup/vue`).
+Validup's model has three nouns — **Container**, **Validator**, **Issue** — and one verb: `Container.run(data)` (with `runSync` / `runParallel` / `safeRun` / `safeRunSync` siblings). Integration packages either produce a `Validator` from a foreign validation library (`@validup/standard-schema`, `@validup/zod`, `@validup/express-validator`) or wire a `Container` into a runtime / framework (`@validup/routup`, `@validup/vue`).
 
 ## Core Types
 
 `packages/validup/src/types.ts`:
 
 ```ts
-export type ValidatorContext = {
+export type ValidatorContext<C = unknown> = {
     key: string,            // expanded mount path inside the current container
     path: PropertyKey[],    // global mount path including parent containers
     value: unknown,         // the value to validate
     data: Record<string, any>, // input of the current container
     group?: string,         // active execution group (if any)
+    context: C,             // caller-supplied context; flows unchanged into nested containers
+    signal?: AbortSignal,   // run-level cancellation signal
 };
 
-export type Validator = (ctx: ValidatorContext) => Promise<unknown> | unknown;
+export type Validator<C = unknown> = (ctx: ValidatorContext<C>) => Promise<unknown> | unknown;
 ```
 
-A `Validator` either returns the (optionally transformed) value or throws — typically a `ValidupValidatorError`/`ValidupError`, but any `Error` is accepted and gets wrapped into an `IssueItem`.
+A `Validator` either returns the (optionally transformed) value or throws — typically a `ValidupValidatorError`/`ValidupError`, but any `Error` is accepted and gets wrapped into an `IssueItem`. Both generics default to `unknown`, so call sites that don't care about typed context compile unchanged.
 
 ## Container
 
-`packages/validup/src/container/module.ts` — the `Container<T>` class.
+`packages/validup/src/container/module.ts` — the `Container<T, C = unknown>` class.
 
 ```ts
 const container = new Container<{ foo: string }>();
@@ -31,8 +33,10 @@ container.mount('foo', { group: ['create'] }, isString); // (path, options, vali
 container.mount(other);                              // mount nested container at root
 container.mount({ group: ['x'] }, other);            // (options, container)
 
-const out = await container.run(data);
-const result = await container.safeRun(data);        // Result<T> = success | error
+const out      = await container.run(data);          // Promise<T>
+const result   = await container.safeRun(data);      // Promise<Result<T>>
+const outSync  = container.runSync(data);            // T — throws if any validator returns a Promise
+const resSync  = container.safeRunSync(data);        // Result<T>
 ```
 
 ### Mount semantics (`module.ts:62`)
@@ -48,63 +52,82 @@ const result = await container.safeRun(data);        // Result<T> = success | er
 
 Only a container can be mounted **without a key** — a validator without a path is a `SyntaxError`.
 
-### `run()` flow (`module.ts:136`)
+### `run()` flow
 
 For each mounted item, in registration order:
 
+0. **Pre-mount abort check** — `options.signal?.throwIfAborted()` runs before each item so a cancelled run short-circuits without entering the per-mount try/catch.
 1. **Group filter** — `isItemGroupIncluded(item, options.group)`. `'*'` always passes; otherwise the item's `group` (string or string[]) must include the active group, or the item must declare no group.
 2. **Path expansion** — `expandPath(data, item.path)` from `pathtrace` (returns `['']` if no path was given, meaning "operate on the whole input").
-3. **Include/exclude filter** — `pathsToInclude` / `pathsToExclude` (run-time options take precedence over container-level options).
-4. **Optional short-circuit** — when `item.options.optional` and `isOptionalValue(value, optionalValue)`, skip; if `optionalInclude` is set, copy the optional value through to output.
+3. **Include/exclude filter** — `pathsToInclude` / `pathsToExclude` (run-time options take precedence over container-level options) via `helpers/path-filter.ts:resolvePathFilter`.
+4. **Optional short-circuit** — `item.options.optional` is either a boolean (paired with `optionalValue`) or a predicate `(value) => boolean`; predicate wins when present. If optional, skip; if `optionalInclude` is set, copy the optional value through to output.
 5. **Dispatch**:
-   - `validator` → `await item.data(ctx)`, write to `output[key]`.
-   - `container` → `await item.data.run(value, { group, flat: true, path: pathAbsolute, pathsToInclude })`. Nested results are merged by `mergePaths(key, childKey)` so dotted paths flatten correctly.
-6. **Error capture** — `ValidupError` issues are re-pathed (parent key prepended); other `Error`s become a single `IssueItem`. Multiple child issues at one path get wrapped in an `IssueGroup`.
-7. **Aggregate**:
+   - `validator` → `await item.data(ctx)` (or `item.data(ctx)` in `runSync`, which throws if the result is thenable). Writes `output[key]`.
+   - `container` → `await item.data.run(value, { group, flat: true, path, pathsToInclude, pathsToExclude, defaults: resolveDefaults(...), context, signal, parallel })`. `runSync` calls `item.data.runSync(...)` (throws `RunSyncViolationError` if the child doesn't implement it). Nested results are merged by `mergePaths(key, childKey)` so dotted paths flatten correctly.
+6. **Error capture** (`recordMountError`) — abort errors and `RunSyncViolationError`s rethrow verbatim (carved out of the issue-folding path). Otherwise: `ValidupError` issues are re-pathed (parent key prepended); other `Error`s become a single `IssueItem`. Multiple child issues at one path get wrapped in an `IssueGroup` whose `params: { name }` lets consumers re-render the message with `formatIssue`.
+7. **Aggregate** (`finalizeOutput`):
    - `oneOf` containers throw only when **every** branch failed (`errorCount === itemCount`), wrapping all issues in a single `IssueGroup` with `code: ONE_OF_FAILED`.
    - Non-`oneOf` containers throw a `ValidupError` with all collected issues if any failed.
    - `defaults` are filled in for missing/`undefined` keys.
    - When `flat` is false (default), the dotted-key `output` is expanded with `setPathValue` into a nested object before returning.
 
+### Execution variants
+
+- **`run`** (default) — sequential `await` per mount.
+- **`runSync`** — same loop without `await`. Validator return values must not be thenable; nested containers must implement `runSync`. Violations throw `RunSyncViolationError` (duck-type guard: `isRunSyncViolation`) and are *not* folded into the issue list.
+- **`runParallel`** (selected via `ContainerRunOptions.parallel: true`) — eagerly kicks off every mount's promise, then awaits them with `Promise.allSettled`. Issues are merged in mount-registration order regardless of which validator rejects first. Trade-off: parallel mode reads `value` from the input `data` only, skipping the sequential mode's `hasOwnProperty(output, key)` chain-read for sanitize-then-validate patterns.
+
+All three variants share the private helpers `resolveContainerFilters` / `recordMountError` / `finalizeOutput` / `wrapSafeRunError` so issue handling stays consistent.
+
 ### Optional values (`helpers/optional-value.ts`)
 
-`OptionalValue` enum controls what counts as "optional":
+`OptionalValue` enum controls what counts as "optional" when `MountOptions.optional: true`:
 
 - `UNDEFINED` (default) — only `undefined`
 - `NULL` — `null` or `undefined`
 - `FALSY` — any falsy value
+
+Pass `optional: (value) => boolean` for cases the enum can't express (e.g. drop empty strings but keep `0`).
 
 ## Issues & Errors
 
 `packages/validup/src/issue/types.ts` — `Issue = IssueItem | IssueGroup` (discriminated by `type`).
 
 ```ts
+interface IssueBase {
+    path: PropertyKey[],
+    message: string,
+    params?: Record<string, unknown>,   // structured payload for lazy re-rendering
+    meta?: Record<string, unknown>,
+}
+
 interface IssueItem extends IssueBase {
     type: 'item',
-    code: string,            // IssueCode.VALUE_INVALID by default
+    code: IssueCode | (string & {}),    // IssueCode.VALUE_INVALID by default
     received?: unknown,
     expected?: unknown,
 }
 
 interface IssueGroup extends IssueBase {
     type: 'group',
-    code?: string,           // e.g. IssueCode.ONE_OF_FAILED
-    issues: Issue[],         // recursive
+    code?: IssueCode | (string & {}),   // e.g. IssueCode.ONE_OF_FAILED
+    issues: Issue[],                    // recursive
 }
 ```
 
-- Always construct with the factories `defineIssueItem(...)` / `defineIssueGroup(...)` — they set `type` correctly.
-- `ValidupError` (`error/base.ts`) is `Error` + `readonly issues: Issue[]`. Its `.message` is auto-built from issue paths via `buildErrorMessageForAttributes`.
-- `isValidupError(e)` is duck-typed (instanceof OR has a valid `issues` array). Use it across package boundaries — direct `instanceof ValidupError` may miss errors from a duplicate copy of the package.
+- Always construct with the factories `defineIssueItem(...)` / `defineIssueGroup(...)` — they set `type` correctly. Pass `params` so consumer-side `formatIssue(issue, templates?)` can re-render the message in another locale.
+- `IssueCode` is a `const` lookup paired with a declaration-mergeable `IssueCodeRegistry` interface — third parties can add typed codes via module augmentation; the `(string & {})` widening keeps ad-hoc strings working too.
+- `ValidupError` (`error/base.ts`) extends `@ebec/core`'s `BaseError` — it carries `code: 'VALIDUP_ERROR'` (auto-derived from the class name), an optional `cause`, `readonly issues: Issue[]`, and a `toJSON()` overridden to include `issues`. The `.message` is still auto-built from issue paths via `buildErrorMessageForAttributes`.
+- `isValidupError(e)` is duck-typed (instanceof OR has a valid `issues` array). Use it across package boundaries — direct `instanceof ValidupError` may miss errors from a duplicate copy of the package. Same pattern for `isRunSyncViolation` (private, internal to `container/`).
 
 ## Integration Package Contract
 
 Integration packages come in two shapes:
 
-1. **Validator adapters** (`@validup/zod`, `@validup/express-validator`) — expose a function that returns a `Validator`. The pattern from `@validup/zod`:
+1. **Validator adapters** (`@validup/standard-schema`, `@validup/zod`, `@validup/express-validator`) — expose a function that returns a `Validator<C>`. The pattern from `@validup/zod`:
 
 ```ts
-export function createValidator(input: ZodCreateFn | ZodType): Validator {
+export function createValidator<C = unknown>(input: ZodCreateFn<C> | ZodType): Validator<C> {
     return async (ctx): Promise<unknown> => {
         const zod = typeof input === 'function' ? input(ctx) : input;
         const outcome = await zod.safeParseAsync(ctx.value);
@@ -114,11 +137,12 @@ export function createValidator(input: ZodCreateFn | ZodType): Validator {
 }
 ```
 
-   Two contract points to preserve when writing or modifying validator adapters:
+   Three contract points to preserve when writing or modifying validator adapters:
 
-   - **Accept `T | (ctx: ValidatorContext) => T`** — letting users build per-context validators (e.g. depending on `ctx.data` or `ctx.group`).
-   - **Translate foreign errors into `Issue[]`** in a separate `error.ts` module, then throw `new ValidupError(issues)`. Use `defineIssueItem`/`defineIssueGroup` — never construct issue objects literally.
+   - **Accept `T | (ctx: ValidatorContext<C>) => T`** — letting users build per-context validators (e.g. depending on `ctx.data`, `ctx.group`, or `ctx.context`).
+   - **Make `createValidator<C>` generic over the validup context type** so the parent `Container<T, C>` keeps `ctx.context` typed end-to-end.
+   - **Translate foreign errors into `Issue[]`** in a separate `error.ts` module, then throw `new ValidupError(issues)`. Use `defineIssueItem`/`defineIssueGroup` — never construct issue objects literally. (`@validup/standard-schema` is a special case: the spec only exposes `message + path`, so the resulting issues carry only the portable subset.)
 
-2. **Framework / runtime integrations** (`@validup/routup`, `@validup/vue`) — consume a whole `Container<T>` and wire it into a host environment.
-   - `@validup/routup` wraps a `Container` for HTTP request inputs and tries each `Location` (`body` / `cookies` / `params` / `query`) until one succeeds, throwing the **last** `ValidupError` if all fail.
-   - `@validup/vue` exposes a `useValidup(container, state, options?)` composable that drives reactive form state from `Container.safeRun()`. Issues come pre-shaped from validup, so there is no `error.ts` module here.
+2. **Framework / runtime integrations** (`@validup/routup`, `@validup/vue`) — consume a whole `Container<T, C>` and wire it into a host environment.
+   - `@validup/routup` wraps a `Container` for HTTP request inputs and tries each `Location` (`body` / `cookies` / `params` / `query`) until one succeeds, throwing the **last** `ValidupError` if all fail. `RoutupContainerRunOptions<T, C>` extends `ContainerRunOptions<T, C>` so `signal`, `context`, and `parallel` flow through automatically.
+   - `@validup/vue` exposes a `useValidup<T, C>(container, state, options?)` composable that drives reactive form state from `Container.safeRun()`. Reactive `options.context` re-runs validation on change; an internal `AbortController` per scheduled run cancels the previous when state/group/context updates (and on `onScopeDispose`). `$validate()` deliberately runs *without* a signal so submit-time runs aren't aborted by intervening keystrokes. Issues come pre-shaped from validup, so there is no `error.ts` module here.

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -28,7 +28,7 @@ Run: `npm run lint` (root, lints the whole workspace via flat config) or `npm ru
 - **Indent**: 4 spaces, LF line endings, UTF-8, final newline (`.editorconfig`).
 - **Single quotes**, trailing commas, semicolons (inherited from the shared config).
 - **`@stylistic/object-curly-newline`** from the shared config requires single-line braces for objects with fewer than 3 properties — `npm run lint:fix` handles this automatically.
-- **Copyright header** on every source file:
+- **Copyright header** on every `.ts` / `.tsx` / `.js` / `.jsx` / `.mjs` / `.cjs` file in the repo — this includes `src/`, `test/`, and build/test config files (`tsdown.config.ts`, `test/vitest.config.ts`, `eslint.config.js`, `commitlint.config.mjs`):
   ```ts
   /*
    * Copyright (c) <year>.
@@ -37,7 +37,7 @@ Run: `npm run lint` (root, lints the whole workspace via flat config) or `npm ru
    * view the LICENSE file that was distributed with this source code.
    */
   ```
-  New files should include this header. Update the year on substantive rewrites (existing files mix `2024`, `2025`, `2026`).
+  New files must include this header. Update the year on substantive rewrites (existing files mix `2024`, `2025`, `2026`).
 - **Index barrels**: every directory under `src/` has an `index.ts` re-exporting its members. Keep this pattern when adding modules — `src/index.ts` re-exports each subdir wholesale.
 - **Imports**: prefer `import type { ... }` for type-only imports. The codebase is consistent about this (see `container/module.ts`).
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -6,6 +6,7 @@
 validup/
 ├── packages/
 │   ├── validup/              # Core library (npm: validup)
+│   ├── standard-schema/      # Standard Schema bridge (npm: @validup/standard-schema)
 │   ├── zod/                  # zod bridge (npm: @validup/zod)
 │   ├── express-validator/    # express-validator bridge (npm: @validup/express-validator)
 │   ├── routup/               # routup HTTP request integration (npm: @validup/routup)
@@ -21,7 +22,8 @@ validup/
 
 | Package                        | Path                          | Public name                  | Depends on (runtime)                | Peer deps                                       |
 |--------------------------------|-------------------------------|------------------------------|-------------------------------------|-------------------------------------------------|
-| Core                           | `packages/validup`            | `validup`                    | `pathtrace`, `smob`                 | —                                               |
+| Core                           | `packages/validup`            | `validup`                    | `@ebec/core`, `pathtrace`, `smob`   | —                                               |
+| Standard Schema integration    | `packages/standard-schema`    | `@validup/standard-schema`   | `@standard-schema/spec`, `validup`  | —                                               |
 | Zod integration                | `packages/zod`                | `@validup/zod`               | `validup`                           | `zod ^3.25.0 \|\| ^4.0.0`                       |
 | express-validator integration  | `packages/express-validator`  | `@validup/express-validator` | `validup`, `smob`                   | `express-validator ^7.3.1`                      |
 | Routup integration             | `packages/routup`             | `@validup/routup`            | (none — `validup` is peer)          | `validup`, `routup`, `@routup/basic`            |
@@ -32,10 +34,11 @@ All packages are `"type": "module"` and publish **ESM-only** (`dist/index.mjs` +
 ## Dependency Layers
 
 ```
-zod ──┐
-express-validator ──┤
-routup ─────┼──► validup ──► pathtrace, smob
-vue ────────┘
+standard-schema ──┐
+zod ──────────────┤
+express-validator ┤
+routup ───────────┼──► validup ──► @ebec/core, pathtrace, smob
+vue ──────────────┘
 ```
 
 - `validup` is the only **leaf** package — integration packages never depend on each other.
@@ -71,8 +74,8 @@ Build scripts per package:
 |--------------|---------------------------------------------------------------------------------------------|
 | `container/` | `Container` class (`module.ts`), `IContainer`/`Mount`/`MountOptions` types, `isContainer`   |
 | `error/`     | `ValidupError` class (`base.ts`) and `isError`/`isValidupError` guards (`check.ts`)         |
-| `issue/`     | `Issue` types (item/group), `IssueCode` enum, `defineIssueItem`/`defineIssueGroup` factories, `isIssue`/`isIssueItem`/`isIssueGroup` guards |
-| `helpers/`   | `buildErrorMessageForAttribute(s)`, `isOptionalValue`, `stringifyPath`                      |
+| `issue/`     | `Issue` types (item/group), `IssueCode` enum, `defineIssueItem`/`defineIssueGroup` factories, `isIssue`/`isIssueItem`/`isIssueGroup` guards, `flattenIssueItems`/`flattenIssueGroups` |
+| `helpers/`   | `buildErrorMessageForAttribute(s)`, `isOptionalValue`, `stringifyPath`, `resolveDefaults`, `resolvePathFilter` |
 | `utils/`     | Internal helpers — `isObject`, `hasOwnProperty`                                             |
 | `constants.ts` | `GroupKey.WILDCARD = '*'`, `OptionalValue` enum (`UNDEFINED` / `NULL` / `FALSY`)          |
 | `types.ts`   | `Validator`, `ValidatorContext`, `ObjectLiteral`                                            |
@@ -91,7 +94,8 @@ src/
 └── index.ts     # Barrel re-export
 ```
 
-- **@validup/zod**: `createValidator(zod | (ctx) => zod)` calls `safeParseAsync`; on failure converts each `ZodIssue` (`$ZodRawIssue` from `zod/v4/core`) into a validup `IssueItem`. Also exports `buildZodIssuesForError` for the reverse direction.
+- **@validup/standard-schema**: `createValidator(schema | (ctx) => schema)` calls `schema['~standard'].validate(ctx.value)` against any [Standard Schema](https://standardschema.dev) library (zod 3.24+, valibot, arktype, effect-schema, …). On failure each `StandardSchemaV1.Issue` becomes a validup `IssueItem`; `path` is normalized so `{ key }`-shape `PathSegment` entries are flattened to `PropertyKey[]`. Vendor-specific fields (zod's `expected`/`received`) are not surfaced — use `@validup/zod` if those matter.
+- **@validup/zod**: `createValidator(zod | (ctx) => zod)` calls `safeParseAsync`; on failure converts each `ZodIssue` (`$ZodRawIssue` from `zod/v4/core`) into a validup `IssueItem`, including `expected` / `received`. Also exports `buildZodIssuesForError` for the reverse direction. Choose this over `@validup/standard-schema` when you need vendor-specific issue fields or bidirectional conversion.
 - **@validup/express-validator**: `createValidator(chain | (ctx) => chain)` runs an express-validator `ContextRunner` with `body: ctx.value`, then translates `ValidationError` (`field` / `alternative` / `alternative_grouped`) into issues. Also exports `createValidationChain()`.
 - **@validup/routup**: `RoutupContainerAdapter` wraps a `Container`; `run(req, options)` reads from `Location` (`body` / `cookies` / `params` / `query`, default `body`) and tries each location until one succeeds.
 - **@validup/vue**: `useValidup(container, state, options?)` is a Vue 3 composable returning a vuelidate-shaped `ValidupComposable<T>` (`$invalid`, `$dirty`, `$pending`, `$errors`, per-field `$model`/`$touch`/`$reset`, plus `$crossCuttingErrors` and `$groupErrors`). Options: `group`, `debounce`, `name`, `stopPropagation`, `detached`, `lazy`, `autoDirty`, `scope`. `stopPropagation` skips upward `inject()` only; `detached` skips both `inject()` and `provide()` (invisible to ancestors *and* descendants). Layout differs slightly: `module.ts` (composable), `helpers/severity.ts` (`getValidupSeverity`), `helpers/child.ts` (`PARENT_INJECTION_KEY` + `extractValidupResultsFromChild`), `types.ts`. No `error.ts` — issues come pre-shaped from the wrapped `Container`.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -22,7 +22,7 @@ Specs reach package source via relative imports — `import { Container } from '
 
 ## Coverage Thresholds
 
-All four packages currently use the same thresholds (`coverage.thresholds` in `vitest.config.ts`):
+All five integration packages currently use the same thresholds (`coverage.thresholds` in `vitest.config.ts`):
 
 | Metric     | Threshold |
 |------------|-----------|

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,6 @@
     "packages/routup": "0.2.2",
     "packages/express-validator": "0.3.2",
     "packages/vue": "0.1.0",
-    "packages/zod": "0.2.4"
+    "packages/zod": "0.2.4",
+    "packages/standard-schema": "0.1.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 # Validup — Agent Guide
 
-Validup is a TypeScript validation library that lets you compose domain-specific validators by mounting `Validator` functions (or nested `Container`s) onto paths of an input object. The runtime expands paths via [pathtrace](https://www.npmjs.com/package/pathtrace), runs each mounted unit, collects structured `Issue`s on failure, and throws a `ValidupError` (or returns a discriminated `Result` via `safeRun`). Integration packages bridge external validators (`@validup/zod`, `@validup/express-validator`) and frameworks (`@validup/routup`, `@validup/vue`) into this model.
+Validup is a TypeScript validation library that lets you compose domain-specific validators by mounting `Validator` functions (or nested `Container`s) onto paths of an input object. The runtime expands paths via [pathtrace](https://www.npmjs.com/package/pathtrace), runs each mounted unit, collects structured `Issue`s on failure, and throws a `ValidupError` (extends `@ebec/core` `BaseError`; or returns a discriminated `Result` via `safeRun`). Integration packages bridge external validators (`@validup/standard-schema`, `@validup/zod`, `@validup/express-validator`) and frameworks (`@validup/routup`, `@validup/vue`) into this model.
 
-The repo is an **Nx-managed npm workspace monorepo** containing the core library and four integration packages (`@validup/zod`, `@validup/express-validator`, `@validup/routup`, `@validup/vue`). The project is pre-1.0 and explicitly marked as work-in-progress.
+The repo is an **Nx-managed npm workspace monorepo** containing the core library and five integration packages (`@validup/standard-schema`, `@validup/zod`, `@validup/express-validator`, `@validup/routup`, `@validup/vue`). The project is pre-1.0 and explicitly marked as work-in-progress.
 
 ## Quick Reference
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This monorepo publishes one core library and four integration packages:
 | Package                                                      | Version                                       | Description                                                              |
 |--------------------------------------------------------------|-----------------------------------------------|--------------------------------------------------------------------------|
 | [`validup`](./packages/validup)                              | [![npm][validup-npm-src]][validup-npm-href]   | Core: `Container`, `Validator`, `Issue`, `ValidupError`                  |
-| [`@validup/zod`](./packages/zod)                             | [![npm][zod-npm-src]][zod-npm-href]           | Bridge to [zod](https://zod.dev) schemas                                 |
+| [`@validup/standard-schema`](./packages/standard-schema)     | [![npm][ss-npm-src]][ss-npm-href]             | Bridge to any [Standard Schema](https://standardschema.dev) library (zod, valibot, arktype, …) |
+| [`@validup/zod`](./packages/zod)                             | [![npm][zod-npm-src]][zod-npm-href]           | Bridge to [zod](https://zod.dev) schemas (vendor-specific issue mapping) |
 | [`@validup/express-validator`](./packages/express-validator) | [![npm][ev-npm-src]][ev-npm-href]             | Bridge to [express-validator](https://express-validator.github.io) chains |
 | [`@validup/routup`](./packages/routup)                       | [![npm][routup-npm-src]][routup-npm-href]     | Run a `Container` against a [routup](https://routup.net) request         |
 | [`@validup/vue`](./packages/vue)                             | [![npm][vue-npm-src]][vue-npm-href]           | [Vue 3](https://vuejs.org) composable for client-side forms              |
@@ -51,7 +52,8 @@ npm install validup --save
 Optionally add an integration:
 
 ```bash
-npm install @validup/zod --save                # zod schemas
+npm install @validup/standard-schema --save    # Standard Schema (zod 3.24+, valibot, arktype, …)
+npm install @validup/zod --save                # zod-specific (richer issue mapping)
 npm install @validup/express-validator --save  # express-validator chains
 npm install @validup/routup --save             # routup HTTP requests
 npm install @validup/vue --save                # Vue 3 forms
@@ -102,6 +104,7 @@ try {
 validup/
 ├── packages/
 │   ├── validup/              # Core library
+│   ├── standard-schema/      # @validup/standard-schema
 │   ├── zod/                  # @validup/zod
 │   ├── express-validator/    # @validup/express-validator
 │   ├── routup/               # @validup/routup
@@ -110,7 +113,7 @@ validup/
 └── release-please-config.json
 ```
 
-The five packages are managed as an [Nx](https://nx.dev) workspace under npm workspaces. Integration packages depend on `validup`; the core has no peer dependencies.
+The six packages are managed as an [Nx](https://nx.dev) workspace under npm workspaces. Integration packages depend on `validup`; the core has a single runtime dep on `@ebec/core`.
 
 ## Development
 
@@ -158,6 +161,8 @@ Published under [MIT License](./LICENSE).
 
 [validup-npm-src]: https://badge.fury.io/js/validup.svg
 [validup-npm-href]: https://npmjs.com/package/validup
+[ss-npm-src]: https://badge.fury.io/js/@validup%2Fstandard-schema.svg
+[ss-npm-href]: https://npmjs.com/package/@validup/standard-schema
 [zod-npm-src]: https://badge.fury.io/js/@validup%2Fzod.svg
 [zod-npm-href]: https://npmjs.com/package/@validup/zod
 [ev-npm-src]: https://badge.fury.io/js/@validup%2Fexpress-validator.svg

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,1 +1,8 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 export default { extends: ['@tada5hi/commitlint-config'] };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import config from '@tada5hi/eslint-config';
 
 export default [

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,6 +494,12 @@
                 }
             }
         },
+        "node_modules/@ebec/core": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@ebec/core/-/core-1.0.1.tgz",
+            "integrity": "sha512-YONiuIHxImAHIBr3EHwmOfMycqSLjlb5RmKUhOPLNC9aoKL4B0JbfpFOqfpIQlexfELQvNXSWdnEYs/uRp6ytA==",
+            "license": "MIT"
+        },
         "node_modules/@ebec/http": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ebec/http/-/http-2.3.0.tgz",
@@ -1516,7 +1522,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@stylistic/eslint-plugin": {
@@ -1970,6 +1975,10 @@
         },
         "node_modules/@validup/routup": {
             "resolved": "packages/routup",
+            "link": true
+        },
+        "node_modules/@validup/standard-schema": {
+            "resolved": "packages/standard-schema",
             "link": true
         },
         "node_modules/@validup/vue": {
@@ -7953,10 +7962,26 @@
                 "validup": "^0.2.2"
             }
         },
+        "packages/standard-schema": {
+            "name": "@validup/standard-schema",
+            "version": "0.1.0",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "validup": "^0.2.2"
+            },
+            "devDependencies": {
+                "zod": "^4.3.6"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            }
+        },
         "packages/validup": {
             "version": "0.2.2",
             "license": "MIT",
             "dependencies": {
+                "@ebec/core": "^1.0.1",
                 "pathtrace": "^2.1.2",
                 "smob": "^1.6.1"
             },

--- a/packages/express-validator/README.md
+++ b/packages/express-validator/README.md
@@ -154,9 +154,9 @@ When the chain succeeds **without** transforming the value, the adapter returns 
 | `buildIssuesForErrors(es)`   | Convert an array of express-validator `ValidationError`s into validup `Issue`s. |
 
 ```typescript
-function createValidator(
-    input: ContextRunner | ((ctx: ValidatorContext) => ContextRunner),
-): Validator;
+function createValidator<C = unknown>(
+    input: ContextRunner | ((ctx: ValidatorContext<C>) => ContextRunner),
+): Validator<C>;
 
 function createValidationChain(): ValidationChain;
 ```

--- a/packages/express-validator/src/module.ts
+++ b/packages/express-validator/src/module.ts
@@ -11,13 +11,13 @@ import type { Issue, Validator, ValidatorContext } from 'validup';
 import { ValidupError } from 'validup';
 import { buildIssuesForErrors } from './error';
 
-type ContextRunnerCreateFn = (
-    ctx: ValidatorContext,
+type ContextRunnerCreateFn<C = unknown> = (
+    ctx: ValidatorContext<C>,
 ) => ContextRunner;
 
-export function createValidator(
-    input: ContextRunnerCreateFn | ContextRunner,
-) : Validator {
+export function createValidator<C = unknown>(
+    input: ContextRunnerCreateFn<C> | ContextRunner,
+) : Validator<C> {
     return async (ctx): Promise<unknown> => {
         let runner : ContextRunner;
         if (typeof input === 'function') {

--- a/packages/express-validator/test/unit/module.spec.ts
+++ b/packages/express-validator/test/unit/module.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { Container, ValidupError } from 'validup';
 import { createValidationChain, createValidator } from '../../src';
 import { UserValidator } from '../data/user';

--- a/packages/express-validator/test/vitest.config.ts
+++ b/packages/express-validator/test/vitest.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/express-validator/tsdown.config.ts
+++ b/packages/express-validator/tsdown.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({

--- a/packages/routup/README.md
+++ b/packages/routup/README.md
@@ -154,13 +154,13 @@ If no location yielded a `ValidupError` (e.g. all fell through silently), the ad
 ## API Reference
 
 ```typescript
-class RoutupContainerAdapter<T extends ObjectLiteral = ObjectLiteral> {
-    constructor(container: Container<T>);
+class RoutupContainerAdapter<T extends ObjectLiteral = ObjectLiteral, C = unknown> {
+    constructor(container: Container<T, C>);
 
-    run(req: Request, options?: RoutupContainerRunOptions<T>): Promise<T>;
+    run(req: Request, options?: RoutupContainerRunOptions<T, C>): Promise<T>;
 }
 
-type RoutupContainerRunOptions<T> = ContainerRunOptions<T> & {
+type RoutupContainerRunOptions<T, C = unknown> = ContainerRunOptions<T, C> & {
     locations?: ('body' | 'cookies' | 'params' | 'query')[]; // default: ['body']
 };
 

--- a/packages/routup/src/module.ts
+++ b/packages/routup/src/module.ts
@@ -15,14 +15,14 @@ import { ValidupError, isValidupError } from 'validup';
 import { Location } from './constants';
 import type { RoutupContainerRunOptions } from './types';
 
-export class RoutupContainerAdapter<T extends ObjectLiteral = ObjectLiteral> {
-    protected container : Container<T>;
+export class RoutupContainerAdapter<T extends ObjectLiteral = ObjectLiteral, C = unknown> {
+    protected container : Container<T, C>;
 
-    constructor(container: Container<T>) {
+    constructor(container: Container<T, C>) {
         this.container = container;
     }
 
-    async run(req: Request, options: RoutupContainerRunOptions<T> = {}) : Promise<T> {
+    async run(req: Request, options: RoutupContainerRunOptions<T, C> = {}) : Promise<T> {
         const locations = options.locations && options.locations.length > 0 ?
             [...options.locations] :
             [Location.BODY];

--- a/packages/routup/src/types.ts
+++ b/packages/routup/src/types.ts
@@ -8,7 +8,7 @@
 import type { ContainerRunOptions, ObjectLiteral } from 'validup';
 import type { Location } from './constants';
 
-export type RoutupContainerRunOptions<T extends ObjectLiteral> = ContainerRunOptions<T> & {
+export type RoutupContainerRunOptions<T extends ObjectLiteral, C = unknown> = ContainerRunOptions<T, C> & {
     /**
      * default: ['body']
      */

--- a/packages/routup/test/unit/module.spec.ts
+++ b/packages/routup/test/unit/module.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { basic } from '@routup/basic';
 import { Router, coreHandler, createNodeDispatcher } from 'routup';
 import { Container, ValidupError } from 'validup';

--- a/packages/routup/test/vitest.config.ts
+++ b/packages/routup/test/vitest.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/routup/tsdown.config.ts
+++ b/packages/routup/tsdown.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -1,0 +1,116 @@
+# @validup/standard-schema 🛡️
+
+A [validup](https://www.npmjs.com/package/validup) integration for any [Standard Schema](https://standardschema.dev) validator — zod (3.24+), valibot, arktype, effect-schema, and any other library that implements the spec.
+
+Mount any Standard Schema as a validup `Validator` on a `Container` path; validup handles path expansion, group filtering, optional/default semantics, and error aggregation while the underlying library does the actual parsing.
+
+> 🚧 **Work in Progress**
+>
+> Validup is currently under active development and is not yet ready for production.
+
+**Table of Contents**
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Per-Context Schemas](#per-context-schemas)
+- [Error Mapping](#error-mapping)
+- [Choosing Between `@validup/zod` and `@validup/standard-schema`](#choosing-between-validupzod-and-validupstandard-schema)
+- [API Reference](#api-reference)
+- [License](#license)
+
+## Installation
+
+```bash
+npm install @validup/standard-schema validup --save
+```
+
+The package depends only on the [`@standard-schema/spec`](https://www.npmjs.com/package/@standard-schema/spec) types and `validup` itself — bring your own schema library.
+
+## Quick Start
+
+```typescript
+import { Container } from 'validup';
+import { createValidator } from '@validup/standard-schema';
+import { z } from 'zod';
+
+const userValidator = new Container<{ email: string; age: number }>();
+
+userValidator.mount('email', createValidator(z.string().email()));
+userValidator.mount('age',   createValidator(z.number().int().positive()));
+
+const user = await userValidator.run({ email: 'foo@example.com', age: 28 });
+```
+
+The same call works for any Standard-Schema-compatible library:
+
+```typescript
+import * as v from 'valibot';
+import { type } from 'arktype';
+
+userValidator.mount('email', createValidator(v.pipe(v.string(), v.email())));
+userValidator.mount('age',   createValidator(type('number > 0')));
+```
+
+## Per-Context Schemas
+
+Pass a function instead of a schema to build the schema lazily from the validator context (e.g. depending on the active group, sibling values, or `ctx.context`):
+
+```typescript
+container.mount(
+    'password',
+    createValidator((ctx) => ctx.group === 'create'
+        ? z.string().min(12)
+        : z.string().min(12).optional()),
+);
+```
+
+The factory receives the full `ValidatorContext`:
+
+```typescript
+type StandardSchemaCreateFn<C = unknown> = (ctx: ValidatorContext<C>) => StandardSchemaV1;
+```
+
+`createValidator<C>(...)` is generic over the validup context type, so factories can read typed `ctx.context` when the parent container declares one (`Container<T, C>`).
+
+## Error Mapping
+
+When a schema's `~standard.validate` returns issues, the adapter converts each one into a validup `IssueItem` carrying the spec-portable subset:
+
+| Standard Schema  | Validup `IssueItem` |
+|------------------|---------------------|
+| `message`        | `message`           |
+| `path` (PropertyKey or `{ key }` PathSegment) | `path` (flattened to `PropertyKey[]`) |
+| —                | `code` defaults to `IssueCode.VALUE_INVALID` |
+
+Vendor-specific fields (zod's `expected`/`received`, valibot's `requirement`, …) aren't part of the spec, so they're not surfaced. If you need them, use the vendor-specific adapter (e.g. `@validup/zod`'s `buildIssuesForZodError`).
+
+The adapter then throws a `ValidupError` with those issues; validup's container catches it and stitches the mount key into each issue's `path`.
+
+## Choosing Between `@validup/zod` and `@validup/standard-schema`
+
+| Want                                                  | Pick                       |
+|-------------------------------------------------------|----------------------------|
+| Vendor-portable adapter — swap libraries without touching mounts | `@validup/standard-schema` |
+| Surface zod's `expected` / `received` on issues       | `@validup/zod`             |
+| Bidirectional `validup ↔ zod` issue conversion        | `@validup/zod`             |
+| zod 3.x (< 3.24, no Standard Schema support)          | `@validup/zod`             |
+
+Both packages can coexist in the same project.
+
+## API Reference
+
+```typescript
+function createValidator<C = unknown>(
+    input: StandardSchemaV1 | ((ctx: ValidatorContext<C>) => StandardSchemaV1),
+): Validator<C>;
+
+function buildIssuesForStandardSchemaIssues(
+    issues: ReadonlyArray<StandardSchemaV1.Issue>,
+): Issue[];
+```
+
+## License
+
+Made with 💚
+
+Published under [MIT License](./LICENSE).

--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "validup",
-    "version": "0.2.2",
+    "name": "@validup/standard-schema",
+    "version": "0.1.0",
     "type": "module",
-    "description": "A validation library.",
+    "description": "A validup integration for any Standard Schema validator (zod, valibot, arktype, effect-schema, …).",
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",
@@ -34,12 +34,21 @@
         "test": "vitest --config test/vitest.config.ts --run",
         "test:coverage": "vitest --config test/vitest.config.ts --run --coverage"
     },
-    "keywords": [],
+    "keywords": [
+        "validup",
+        "standard-schema",
+        "validation",
+        "zod",
+        "valibot",
+        "arktype"
+    ],
     "license": "MIT",
     "dependencies": {
-        "@ebec/core": "^1.0.1",
-        "pathtrace": "^2.1.2",
-        "smob": "^1.6.1"
+        "@standard-schema/spec": "^1.1.0",
+        "validup": "^0.2.2"
+    },
+    "devDependencies": {
+        "zod": "^4.3.6"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/standard-schema/src/error.ts
+++ b/packages/standard-schema/src/error.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { defineIssueItem } from 'validup';
+import type { Issue } from 'validup';
+
+/**
+ * Convert a Standard Schema path (`(PropertyKey | { key })[]`) into a validup
+ * `PropertyKey[]`. PathSegments are unwrapped to their `.key`.
+ */
+function normalizePath(
+    path: ReadonlyArray<PropertyKey | StandardSchemaV1.PathSegment> | undefined,
+): PropertyKey[] {
+    if (!path || path.length === 0) {
+        return [];
+    }
+
+    const output: PropertyKey[] = [];
+    for (const segment of path) {
+        if (
+            typeof segment === 'object' &&
+            segment !== null &&
+            'key' in segment
+        ) {
+            output.push(segment.key);
+        } else {
+            output.push(segment);
+        }
+    }
+    return output;
+}
+
+/**
+ * Translate Standard Schema issues into validup `IssueItem`s. Standard Schema
+ * intentionally only exposes `message` + `path`; vendor-specific fields like
+ * `expected`/`received`/`code` are not part of the spec, so the resulting
+ * issues carry only the portable subset (`code` defaults to
+ * `IssueCode.VALUE_INVALID`).
+ */
+export function buildIssuesForStandardSchemaIssues(
+    issues: ReadonlyArray<StandardSchemaV1.Issue>,
+): Issue[] {
+    const output: Issue[] = [];
+    for (const issue of issues) {
+        output.push(defineIssueItem({
+            path: normalizePath(issue.path),
+            message: issue.message,
+        }));
+    }
+    return output;
+}

--- a/packages/standard-schema/src/error.ts
+++ b/packages/standard-schema/src/error.ts
@@ -6,7 +6,7 @@
  */
 
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { defineIssueItem } from 'validup';
+import { defineIssueItem, isObject } from 'validup';
 import type { Issue } from 'validup';
 
 /**
@@ -22,14 +22,10 @@ function normalizePath(
 
     const output: PropertyKey[] = [];
     for (const segment of path) {
-        if (
-            typeof segment === 'object' &&
-            segment !== null &&
-            'key' in segment
-        ) {
-            output.push(segment.key);
+        if (isObject(segment) && 'key' in segment) {
+            output.push(segment.key as PropertyKey);
         } else {
-            output.push(segment);
+            output.push(segment as PropertyKey);
         }
     }
     return output;

--- a/packages/standard-schema/src/index.ts
+++ b/packages/standard-schema/src/index.ts
@@ -1,12 +1,9 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './defaults';
 export * from './error';
-export * from './optional-value';
-export * from './path-filter';
-export * from './path-stringify';
+export * from './module';

--- a/packages/standard-schema/src/module.ts
+++ b/packages/standard-schema/src/module.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type { Validator, ValidatorContext } from 'validup';
+import { ValidupError } from 'validup';
+import { buildIssuesForStandardSchemaIssues } from './error';
+
+type StandardSchemaCreateFn<C = unknown> = (
+    ctx: ValidatorContext<C>,
+) => StandardSchemaV1;
+
+/**
+ * Wrap any Standard Schema validator (zod 3.24+, valibot, arktype,
+ * effect-schema, …) as a validup `Validator`. The schema's `~standard.validate`
+ * method is invoked with the mounted value; on failure, its issues are
+ * translated into validup `IssueItem`s.
+ *
+ * Pass a function instead of a schema to build per-context schemas
+ * (e.g. depending on the active group, sibling values, or `ctx.context`).
+ */
+export function createValidator<C = unknown>(
+    input: StandardSchemaV1 | StandardSchemaCreateFn<C>,
+): Validator<C> {
+    return async (ctx): Promise<unknown> => {
+        const schema = typeof input === 'function' ? input(ctx) : input;
+        const result = await schema['~standard'].validate(ctx.value);
+
+        if (!result.issues) {
+            return result.value;
+        }
+
+        throw new ValidupError(buildIssuesForStandardSchemaIssues(result.issues));
+    };
+}

--- a/packages/standard-schema/test/unit/module.spec.ts
+++ b/packages/standard-schema/test/unit/module.spec.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { Container, ValidupError } from 'validup';
+import { buildIssuesForStandardSchemaIssues, createValidator } from '../../src';
+
+describe('@validup/standard-schema', () => {
+    it('should validate via a Standard Schema (zod 4)', async () => {
+        const validator = new Container<{ email: string }>();
+        validator.mount('email', createValidator(z.string().email()));
+
+        const outcome = await validator.run({ email: 'foo@example.com' });
+
+        expect(outcome.email).toEqual('foo@example.com');
+    });
+
+    it('should accept a factory that builds the schema from context', async () => {
+        const validator = new Container<{ email: string }>();
+        validator.mount('email', createValidator((ctx) => {
+            // Schema can depend on validator context (group/data/context).
+            expect(ctx.key).toEqual('email');
+            return z.string().email();
+        }));
+
+        const outcome = await validator.run({ email: 'foo@example.com' });
+        expect(outcome.email).toEqual('foo@example.com');
+    });
+
+    it('should translate Standard Schema issues into validup IssueItems', async () => {
+        const validator = new Container<{ email: string }>();
+        validator.mount('email', createValidator(z.string().email()));
+
+        expect.assertions(3);
+        try {
+            await validator.run({ email: 'not-an-email' });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                expect(e.issues).toHaveLength(1);
+                expect(e.issues[0]?.path).toEqual(['email']);
+                expect(e.issues[0]?.message).toEqual('Invalid email address');
+            }
+        }
+    });
+
+    it('should normalize PathSegment objects in nested schemas', async () => {
+        const validator = new Container<{ foo: unknown }>();
+        validator.mount(
+            'foo',
+            createValidator(z.object({ bar: z.string().array().min(2) })),
+        );
+
+        expect.assertions(3);
+        try {
+            await validator.run({ foo: { bar: [0] } });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                // Multiple schema-side issues collapse into an IssueGroup at
+                // the mount path; the inner issues carry the merged paths.
+                const [group] = e.issues;
+                if (group?.type === 'group') {
+                    const innerPaths = group.issues.map((i) => i.path);
+                    expect(innerPaths).toContainEqual(['foo', 'bar', 0]);
+                    expect(innerPaths).toContainEqual(['foo', 'bar']);
+                    expect(group.issues.every((i) => i.type === 'item')).toBe(true);
+                }
+            }
+        }
+    });
+
+    it('should accept a synthetic Standard Schema (vendor-agnostic)', async () => {
+        // Hand-rolled schema to verify the adapter doesn't depend on zod internals.
+        const greaterThan10 = {
+            '~standard': {
+                version: 1 as const,
+                vendor: 'test',
+                validate(value: unknown) {
+                    if (typeof value === 'number' && value > 10) {
+                        return { value };
+                    }
+                    return {
+                        issues: [
+                            {
+                                // Path is relative to the validated value;
+                                // validup prepends the mount key.
+                                message: 'must be greater than 10',
+                            },
+                        ],
+                    };
+                },
+            },
+        };
+
+        const validator = new Container<{ amount: number }>();
+        validator.mount('amount', createValidator(greaterThan10));
+
+        const ok = await validator.run({ amount: 42 });
+        expect(ok.amount).toEqual(42);
+
+        expect.assertions(3);
+        try {
+            await validator.run({ amount: 5 });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                expect(e.issues[0]?.message).toEqual('must be greater than 10');
+                expect(e.issues[0]?.path).toEqual(['amount']);
+            }
+        }
+    });
+
+    it('should normalize PathSegment objects ({ key }) when present', () => {
+        // Some Standard Schema vendors (notably valibot) emit `{ key }`
+        // wrappers in path. Verify normalizePath unwraps them.
+        const out = buildIssuesForStandardSchemaIssues([
+            { message: 'invalid', path: [{ key: 'foo' }, { key: 0 }, 'bar'] },
+        ]);
+        expect(out[0]?.path).toEqual(['foo', 0, 'bar']);
+    });
+});

--- a/packages/standard-schema/test/vitest.config.ts
+++ b/packages/standard-schema/test/vitest.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/standard-schema/test/vitest.config.ts
+++ b/packages/standard-schema/test/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            thresholds: {
+                branches: 59,
+                functions: 77,
+                lines: 73,
+                statements: 74,
+            },
+        },
+    },
+});

--- a/packages/standard-schema/tsconfig.json
+++ b/packages/standard-schema/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/packages/standard-schema/tsdown.config.ts
+++ b/packages/standard-schema/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: 'src/index.ts',
+    format: 'esm',
+    dts: true,
+    sourcemap: true,
+});

--- a/packages/standard-schema/tsdown.config.ts
+++ b/packages/standard-schema/tsdown.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -32,7 +32,12 @@ Mount any validator function (or nested container) onto any path of your input, 
 - [oneOf Branches](#oneof-branches)
 - [Path Filtering](#path-filtering)
 - [Defaults](#defaults)
+- [Context](#context)
+- [Cancellation](#cancellation)
+- [Parallel Execution](#parallel-execution)
 - [Safe Run](#safe-run)
+- [Sync Fast Path](#sync-fast-path)
+- [Localized Messages](#localized-messages)
 - [Error Handling](#error-handling)
   - [ValidupError](#validuperror)
   - [Issue Shape](#issue-shape)
@@ -94,14 +99,16 @@ try {
 A validator is a (sync or async) function that receives a `ValidatorContext` and either returns the validated/transformed value or throws.
 
 ```typescript
-type Validator = (ctx: ValidatorContext) => Promise<unknown> | unknown;
+type Validator<C = unknown> = (ctx: ValidatorContext<C>) => Promise<unknown> | unknown;
 
-type ValidatorContext = {
+type ValidatorContext<C = unknown> = {
     key: string;            // expanded mount path within the current container
     path: PropertyKey[];    // global mount path including parent containers
     value: unknown;         // the value to validate
     data: Record<string, any>; // input of the current container
     group?: string;         // active execution group, if any
+    context: C;             // caller-supplied context (see [Context](#context))
+    signal?: AbortSignal;   // cancellation signal (see [Cancellation](#cancellation))
 };
 ```
 
@@ -109,7 +116,7 @@ A validator's **return value** becomes the output for that path — so validator
 
 ### Containers
 
-A `Container<T>` holds an ordered list of mounts and runs them against an input object. The optional generic `T` constrains mount keys and shapes the resolved output.
+A `Container<T, C>` holds an ordered list of mounts and runs them against an input object. The optional generic `T` constrains mount keys and shapes the resolved output; the optional `C` types the caller-supplied [context](#context).
 
 ```typescript
 const container = new Container<{ name: string; age: number }>();
@@ -284,6 +291,17 @@ container.mount('nickname',
 await container.run({});  // → { nickname: undefined }
 ```
 
+For cases the `optionalValue` enum can't express (e.g. "drop empty string but keep `0`"), pass `optional` as a predicate. Custom predicates win when present and `optionalValue` is ignored:
+
+```typescript
+container.mount('name',
+    { optional: (v) => v === '' || typeof v === 'undefined' },
+    isString,
+);
+
+await container.run({ name: '', count: 0 });  // ✅ name skipped, count validated
+```
+
 ## oneOf Branches
 
 A container created with `{ oneOf: true }` succeeds if **any one** of its mounts succeeds. Failures are aggregated into a single `IssueGroup` only when **all** branches fail.
@@ -323,6 +341,67 @@ await container.run({}, {
 // → { role: 'user', active: true }
 ```
 
+Dotted keys target nested-container output and are sliced through to the matching child:
+
+```typescript
+await parent.run({}, {
+    defaults: { 'profile.role': 'user' },
+});
+// → { profile: { role: 'user' } }
+```
+
+## Context
+
+Pass request-scoped data (current user, locale, DB connection, request id) to your validators without going through closures or globals. The `context` flows through every nested container unchanged.
+
+```typescript
+type AppContext = { userId: string };
+
+const container = new Container<{ slug: string }, AppContext>();
+
+container.mount('slug', async (ctx) => {
+    // ctx.context is typed as AppContext
+    const exists = await db.slugExists(ctx.value, ctx.context.userId);
+    if (exists) {
+        throw new Error('Slug already taken');
+    }
+    return ctx.value;
+});
+
+await container.run({ slug: 'my-post' }, { context: { userId: 'u-42' } });
+```
+
+The `C` parameter on `Container<T, C>`, `Validator<C>`, and `ValidatorContext<C>` defaults to `unknown`, so existing code without a context type compiles unchanged.
+
+## Cancellation
+
+Pass an `AbortSignal` to abort a run between mounts. The container checks `signal.aborted` before each mount and rethrows `signal.reason`; the signal is also forwarded into `ValidatorContext.signal` so async validators can cancel their own I/O (e.g. `fetch(url, { signal: ctx.signal })`).
+
+```typescript
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 100);
+
+try {
+    await container.run(input, { signal: controller.signal });
+} catch (e) {
+    // AbortError — not a ValidupError
+}
+```
+
+`safeRun()` rethrows the abort reason (it is never wrapped into a `Result.failure`) so callers can distinguish "validation failed" from "operation cancelled".
+
+## Parallel Execution
+
+By default mounts run sequentially in registration order. For containers whose mounts hit independent slow async resources (multiple DB lookups, HTTP calls), opt into parallel mode:
+
+```typescript
+await container.run(input, { parallel: true });
+```
+
+All mounts kick off concurrently and the results merge in registration order — `issues[]` ordering is unchanged. The flag is forwarded into nested containers so the whole tree runs concurrently.
+
+**Trade-off**: in parallel mode each mount captures its `value` from the input `data` *before* any sibling mount runs, so a later mount can no longer read an earlier mount's transformed `output[key]`. Stick with sequential mode (the default) for chained-key sanitize-then-validate patterns.
+
 ## Safe Run
 
 `safeRun()` returns a discriminated `Result<T>` instead of throwing — handy when you want to deal with errors without `try/catch`:
@@ -337,17 +416,59 @@ if (result.success) {
 }
 ```
 
+## Sync Fast Path
+
+When every mounted validator (and every nested container's `runSync`) is synchronous, use `runSync()` / `safeRunSync()` to skip the per-mount microtask overhead of `await`:
+
+```typescript
+const out = container.runSync(input);  // returns T directly, not Promise<T>
+```
+
+`runSync()` throws synchronously if a validator returns a Promise or if a nested container does not implement `runSync` — those are *structural* failures (not validation outcomes), so they're surfaced verbatim and never wrapped into `Result.failure` by `safeRunSync`. Use the async `run()` for any graph that mixes sync and async validators.
+
+## Localized Messages
+
+`Issue.message` is rendered eagerly in English at construction time. For i18n / custom locales, every issue also carries a structured `params?: Record<string, unknown>` field (populated by the runtime where the message references a non-trivial value — e.g. `{ name: 'email' }` on the wrapping group at a failing mount). Pair it with `formatIssue` and a `code → template` map to render at the consumer side:
+
+```typescript
+import { formatIssue, type IssueMessageTemplates } from 'validup';
+
+const de: IssueMessageTemplates = {
+    value_invalid: 'Feld {name} ist ungültig',
+    one_of_failed: 'Keine der Varianten war erfolgreich',
+};
+
+for (const issue of error.issues) {
+    console.log(formatIssue(issue, de));   // Feld email ist ungültig
+}
+```
+
+`formatIssue(issue, templates?, fallback?)`:
+
+1. If `templates[issue.code]` exists, returns `interpolate(template, issue.params)` (placeholders use the `{name}` syntax from `@ebec/core`).
+2. Otherwise returns `issue.message`.
+3. Otherwise returns `fallback`.
+
+Custom validators that want to participate in this flow should pass `params` through `defineIssueItem`/`defineIssueGroup` so consumer-side templates can reference field-specific values. The default `interpolate` is also re-exported for ad-hoc rendering.
+
 ## Error Handling
 
 ### ValidupError
 
 ```typescript
-class ValidupError extends Error {
+import type { BaseError } from '@ebec/core';
+
+class ValidupError extends BaseError {
+    readonly code: string;        // 'VALIDUP_ERROR' (auto-derived from class name)
     readonly issues: Issue[];
+    cause?: unknown;              // inherited from BaseError
+    toJSON(): { name, message, code, cause?, issues };
 }
 ```
 
-The `message` is auto-built from the failing paths (`Property foo is invalid`, `Properties foo, bar are invalid`).
+`ValidupError` extends [`@ebec/core`](https://github.com/tada5hi/ebec)'s `BaseError`, so it ships with a `code`, an optional `cause`, and a `toJSON()` for clean transport across HTTP/JSON boundaries. The `message` is auto-built from the failing paths (`Property foo is invalid`, `Properties foo, bar are invalid`).
+
+Subclass `ValidupError` (or `BaseError` directly) when you need a domain-specific code — ebec derives it from the class name automatically.
 
 Use `isValidupError(err)` to check across package boundaries. It is duck-typed (instanceof OR has a valid `issues` array), so it tolerates the case where two copies of `validup` exist in the dependency tree.
 
@@ -408,21 +529,43 @@ const group = defineIssueGroup({
 | `IssueCode.VALUE_INVALID`     | Default for any `defineIssueItem(...)` without a code |
 | `IssueCode.ONE_OF_FAILED`     | All branches of a `oneOf` container failed            |
 
+The `IssueCode` const exposes the well-known runtime values; the matching `IssueCode` *type* (declaration-merged with the `IssueCodeRegistry` interface) gives autocomplete on `IssueItem.code`. Third-party packages can register their own codes:
+
+```typescript
+declare module 'validup' {
+    interface IssueCodeRegistry {
+        EMAIL_TAKEN: 'email_taken';
+    }
+}
+
+defineIssueItem({ code: 'email_taken', path: ['email'], message: '…' });
+// → autocompletes 'email_taken' alongside the built-ins
+```
+
+Codes that don't need a registry entry still work — `IssueItem.code` is widened to `IssueCode | (string & {})` so ad-hoc strings stay valid.
+
 ## API Reference
 
 ### Container
 
 ```typescript
-class Container<T extends Record<string, any> = Record<string, any>> implements IContainer<T> {
+class Container<
+    T extends Record<string, any> = Record<string, any>,
+    C = unknown,
+> implements IContainer<T, C> {
     constructor(options?: ContainerOptions<T>);
 
     mount(container: IContainer): void;
     mount(options: MountOptions, container: IContainer): void;
-    mount(key: Path<T>, data: IContainer | Validator): void;
-    mount(key: Path<T>, options: MountOptions, data: IContainer | Validator): void;
+    mount(key: Path<T>, data: IContainer | Validator<C>): void;
+    mount(key: Path<T>, options: MountOptions, data: IContainer | Validator<C>): void;
 
-    run(input?: Record<string, any>, options?: ContainerRunOptions<T>): Promise<T>;
-    safeRun(input?: Record<string, any>, options?: ContainerRunOptions<T>): Promise<Result<T>>;
+    run(input?: Record<string, any>, options?: ContainerRunOptions<T, C>): Promise<T>;
+    safeRun(input?: Record<string, any>, options?: ContainerRunOptions<T, C>): Promise<Result<T>>;
+
+    // Sync variants — throw if any validator returns a Promise.
+    runSync(input?: Record<string, any>, options?: ContainerRunOptions<T, C>): T;
+    safeRunSync(input?: Record<string, any>, options?: ContainerRunOptions<T, C>): Result<T>;
 }
 ```
 
@@ -432,6 +575,9 @@ class Container<T extends Record<string, any> = Record<string, any>> implements 
 | `pathsToInclude`          | `ContainerOptions`, `ContainerRunOptions` | Only mount paths in this list are executed     |
 | `pathsToExclude`          | `ContainerOptions`, `ContainerRunOptions` | Mount paths in this list are skipped           |
 | `defaults`                | `ContainerRunOptions`  | Fallback values for missing/`undefined` keys                      |
+| `context`                 | `ContainerRunOptions`  | Caller-supplied value surfaced on `ValidatorContext.context`      |
+| `signal`                  | `ContainerRunOptions`  | `AbortSignal` — checked between mounts and forwarded to `ctx.signal` |
+| `parallel`                | `ContainerRunOptions`  | Run mounts concurrently (forwarded into nested containers)        |
 | `group`                   | `ContainerRunOptions`  | Active group (only matching mounts run; `'*'` runs everything)    |
 | `flat`                    | `ContainerRunOptions`  | When `true`, the output is a dotted-key map instead of nested     |
 | `path`                    | `ContainerRunOptions`  | Used internally when nesting; rarely set by hand                  |
@@ -467,7 +613,8 @@ Use one of the official integration packages to bridge an existing validator lib
 
 | Package                                                                              | Connects                                                                       |
 |--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
-| [`@validup/zod`](https://npmjs.com/package/@validup/zod)                             | [zod](https://zod.dev) schemas                                                 |
+| [`@validup/standard-schema`](https://npmjs.com/package/@validup/standard-schema)     | Any [Standard Schema](https://standardschema.dev) library — zod 3.24+, valibot, arktype, effect-schema, … |
+| [`@validup/zod`](https://npmjs.com/package/@validup/zod)                             | [zod](https://zod.dev) schemas (vendor-specific issue mapping with `expected` / `received`) |
 | [`@validup/express-validator`](https://npmjs.com/package/@validup/express-validator) | [express-validator](https://express-validator.github.io) chains                |
 | [`@validup/routup`](https://npmjs.com/package/@validup/routup)                       | [routup](https://routup.net) request inputs (body / query / cookies / params)  |
 | [`@validup/vue`](https://npmjs.com/package/@validup/vue)                             | [Vue 3](https://vuejs.org) composable for reactive client-side form state      |

--- a/packages/validup/src/container/module.ts
+++ b/packages/validup/src/container/module.ts
@@ -14,112 +14,34 @@ import {
 } from 'pathtrace';
 import { GroupKey } from '../constants';
 import { ValidupError, isError, isValidupError } from '../error';
-import { buildErrorMessageForAttribute, isOptionalValue } from '../helpers';
+import {
+    buildErrorMessageForAttribute,
+    isOptionalValue,
+    resolveDefaults,
+    resolvePathFilter,
+} from '../helpers';
 import type { Validator } from '../types';
 import { hasOwnProperty, isObject } from '../utils';
 import { isContainer } from './check';
 import type {
-    ContainerOptions, 
-    ContainerRunOptions, 
-    IContainer, 
-    Mount, 
-    MountOptions, 
+    ContainerOptions,
+    ContainerRunOptions,
+    IContainer,
+    Mount,
+    MountOptions,
     Result,
 } from './types';
 import type { Issue } from '../issue';
 import { IssueCode, defineIssueGroup, defineIssueItem } from '../issue';
-
-type PathFilterResolution = {
-    skip: boolean,
-    pathsToInclude: string[] | undefined,
-    pathsToExclude: string[] | undefined,
-};
-
-/**
- * Resolve `pathsToInclude` / `pathsToExclude` against a single mounted item's
- * (already-expanded) local `key`. Returns whether to skip the item, plus the
- * filter sub-lists to forward into a child container — with the parent prefix
- * stripped so the child can match purely against its own local keys.
- *
- * Semantics:
- * - Un-keyed container mount (`key === ''`) shares the parent's namespace, so
- *   filters are forwarded verbatim.
- * - Exact match in `pathsToInclude` / `pathsToExclude` matches the whole mount.
- * - Prefix match (`<key>.…`) only descends into container mounts; leaf
- *   validators with deeper-target filters fall through (skipped for include,
- *   kept for exclude).
- */
-function resolvePathFilter(
-    pathsToInclude: string[] | undefined,
-    pathsToExclude: string[] | undefined,
-    key: string,
-    isContainer: boolean,
-): PathFilterResolution {
-    if (key.length === 0) {
-        return {
-            skip: false, 
-            pathsToInclude, 
-            pathsToExclude, 
-        };
-    }
-
-    let includeForward: string[] | undefined;
-    if (typeof pathsToInclude !== 'undefined') {
-        let exact = false;
-        const stripped: string[] = [];
-        for (const path of pathsToInclude) {
-            if (path === key) {
-                exact = true;
-            } else if (isContainer && path.startsWith(`${key}.`)) {
-                stripped.push(path.slice(key.length + 1));
-            }
-        }
-        if (exact) {
-            includeForward = undefined;
-        } else if (stripped.length > 0) {
-            includeForward = stripped;
-        } else {
-            return {
-                skip: true, 
-                pathsToInclude: undefined, 
-                pathsToExclude: undefined, 
-            };
-        }
-    }
-
-    let excludeForward: string[] | undefined;
-    if (typeof pathsToExclude !== 'undefined') {
-        const stripped: string[] = [];
-        for (const path of pathsToExclude) {
-            if (path === key) {
-                return {
-                    skip: true, 
-                    pathsToInclude: undefined, 
-                    pathsToExclude: undefined, 
-                };
-            }
-            if (isContainer && path.startsWith(`${key}.`)) {
-                stripped.push(path.slice(key.length + 1));
-            }
-        }
-        if (stripped.length > 0) {
-            excludeForward = stripped;
-        }
-    }
-
-    return {
-        skip: false, 
-        pathsToInclude: includeForward, 
-        pathsToExclude: excludeForward, 
-    };
-}
+import { RunSyncViolationError, isRunSyncViolation } from './run-sync-violation';
 
 export class Container<
     T extends Record<string, any> = Record<string, any>,
-> implements IContainer {
+    C = unknown,
+> implements IContainer<T, C> {
     protected options : ContainerOptions<T>;
 
-    protected items : Mount[];
+    protected items : Mount<C>[];
 
     // ----------------------------------------------
 
@@ -132,22 +54,22 @@ export class Container<
 
     // ----------------------------------------------
 
-    mount(container: IContainer) : void;
+    mount(container: IContainer<any, any>) : void;
 
     mount(
         options: MountOptions,
-        container: IContainer
+        container: IContainer<any, any>
     ): void;
 
     mount(
         key: Path<T> | (string & {}),
-        data: IContainer | Validator
+        data: IContainer<any, any> | Validator<C>
     ) : void;
 
     mount(
         key: Path<T> | (string & {}),
         options: MountOptions,
-        data: IContainer | Validator
+        data: IContainer<any, any> | Validator<C>
     ) : void;
 
     mount(...args: any[]) : void {
@@ -157,7 +79,7 @@ export class Container<
 
         let path : string | undefined;
 
-        let data: IContainer | Validator | undefined;
+        let data: IContainer<any, any> | Validator<C> | undefined;
         let dataIsContainer : boolean = false;
 
         let options: MountOptions = {};
@@ -208,7 +130,7 @@ export class Container<
 
         this.items.push({
             options,
-            data,
+            data: data as Validator<C>,
             path,
             type: 'validator',
         });
@@ -224,46 +146,36 @@ export class Container<
      */
     async run(
         data: Record<string, any> = {},
-        options: ContainerRunOptions<T> = {},
+        options: ContainerRunOptions<T, C> = {},
     ): Promise<T> {
-        let pathsToInclude : string[] | undefined;
-        if (options.pathsToInclude) {
-            pathsToInclude = options.pathsToInclude as string[];
-        } else if (this.options.pathsToInclude) {
-            pathsToInclude = this.options.pathsToInclude as string[];
+        if (options.parallel) {
+            return this.runParallel(data, options);
         }
 
-        let pathsToExclude : string[] | undefined;
-        if (options.pathsToExclude) {
-            pathsToExclude = options.pathsToExclude as string[];
-        } else if (this.options.pathsToExclude) {
-            pathsToExclude = this.options.pathsToExclude as string[];
-        }
+        const { pathsToInclude, pathsToExclude } = this.resolveContainerFilters(options);
 
         const output: Record<string, any> = {};
+        const issues: Issue[] = [];
 
-        const issues : Issue[] = [];
-
-        let itemCount : number = 0;
-        let errorCount : number = 0;
+        let itemCount = 0;
+        let errorCount = 0;
 
         for (let i = 0; i < this.items.length; i++) {
+            // Pre-mount abort check — cheap and short-circuits cleanly without
+            // entering the per-mount try/catch (so aborts don't get rewritten
+            // into validation issues).
+            options.signal?.throwIfAborted();
+
             const item = this.items[i];
 
             if (!this.isItemGroupIncluded(item, options.group)) {
-                // todo: maybe add issue info
                 continue;
             }
 
             let pathCount = 0;
             let pathFailed = false;
 
-            let keys : string[];
-            if (item.path) {
-                keys = expandPath(data, item.path);
-            } else {
-                keys = [''];
-            }
+            const keys: string[] = item.path ? expandPath(data, item.path) : [''];
 
             for (const key of keys) {
                 const keyParts = key ? pathToArray(key) : [];
@@ -274,7 +186,7 @@ export class Container<
                     ...keyParts,
                 ];
 
-                let value : unknown;
+                let value: unknown;
                 if (key.length > 0) {
                     value = hasOwnProperty(output, key) ?
                         output[key] :
@@ -290,15 +202,16 @@ export class Container<
                     item.type === 'container',
                 );
                 if (filter.skip) {
-                    // todo: maybe add issue info
                     continue;
                 }
 
                 try {
-                    if (
+                    const isOptional = typeof item.options.optional === 'function' ?
+                        item.options.optional(value) :
                         item.options.optional &&
-                        isOptionalValue(value, item.options.optionalValue)
-                    ) {
+                            isOptionalValue(value, item.options.optionalValue);
+
+                    if (isOptional) {
                         if (item.options.optionalInclude) {
                             output[key] = value;
                         }
@@ -311,7 +224,9 @@ export class Container<
                                 path: pathAbsolute,
                                 pathsToInclude: filter.pathsToInclude,
                                 pathsToExclude: filter.pathsToExclude,
-                                // todo: extract defaults for container
+                                defaults: resolveDefaults(options.defaults, key),
+                                context: options.context,
+                                signal: options.signal,
                             },
                         );
 
@@ -327,46 +242,12 @@ export class Container<
                             value,
                             data,
                             group: options.group,
+                            context: options.context as C,
+                            signal: options.signal,
                         });
                     }
                 } catch (e) {
-                    const childIssues : Issue[] = [];
-
-                    if (isValidupError(e)) {
-                        for (let i = 0; i < e.issues.length; i++) {
-                            const issue = e.issues[i];
-
-                            childIssues.push({
-                                ...issue,
-                                path: [
-                                    ...keyParts,
-                                    ...(issue.path || []),
-                                ],
-                            });
-                        }
-                    } else if (isError(e)) {
-                        childIssues.push(defineIssueItem({
-                            path: keyParts,
-                            message: e.message,
-                        }));
-                    }
-
-                    if (pathRelative) {
-                        if (item.type === 'container' || childIssues.length > 1) {
-                            const group = defineIssueGroup({
-                                message: buildErrorMessageForAttribute(pathRelative),
-                                path: keyParts,
-                                issues: childIssues,
-                            });
-
-                            issues.push(group);
-                        } else {
-                            issues.push(...childIssues);
-                        }
-                    } else {
-                        issues.push(...childIssues);
-                    }
-
+                    this.recordMountError(e, item, keyParts, pathRelative, issues, options.signal);
                     pathFailed = true;
                 }
 
@@ -382,6 +263,446 @@ export class Container<
             }
         }
 
+        return this.finalizeOutput(output, options, issues, errorCount, itemCount);
+    }
+
+    /**
+     * Parallel-execution variant of `run()`. All mounts kick off their
+     * promises eagerly and the results are merged after `Promise.allSettled`.
+     * See `ContainerRunOptions.parallel` for the trade-off note.
+     */
+    private async runParallel(
+        data: Record<string, any>,
+        options: ContainerRunOptions<T, C>,
+    ): Promise<T> {
+        const { pathsToInclude, pathsToExclude } = this.resolveContainerFilters(options);
+
+        const output: Record<string, any> = {};
+        const issues: Issue[] = [];
+
+        type KeyTask = {
+            key: string,
+            keyParts: PropertyKey[],
+            pathRelative: PropertyKey | undefined,
+            promise: Promise<unknown>,
+            kind: 'container' | 'validator',
+        };
+
+        type ItemGroup = {
+            item: Mount<C>,
+            tasks: KeyTask[],
+            // optional/skip paths that completed inline still count toward
+            // the per-item pathCount used for oneOf / errorCount tracking.
+            syncPathCount: number,
+        };
+
+        const itemGroups: ItemGroup[] = [];
+
+        for (let i = 0; i < this.items.length; i++) {
+            options.signal?.throwIfAborted();
+
+            const item = this.items[i];
+            if (!this.isItemGroupIncluded(item, options.group)) {
+                continue;
+            }
+
+            const tasks: KeyTask[] = [];
+            let syncPathCount = 0;
+
+            const keys: string[] = item.path ? expandPath(data, item.path) : [''];
+            for (const key of keys) {
+                const keyParts = key ? pathToArray(key) : [];
+                const pathRelative = keyParts.at(-1);
+                const pathAbsolute = [
+                    ...(options.path ? options.path : []),
+                    ...keyParts,
+                ];
+
+                let value: unknown;
+                if (key.length > 0) {
+                    // Parallel mode reads `data` only — `output[key]` from a
+                    // sibling mount is intentionally NOT consulted (the
+                    // sibling may not have completed yet).
+                    value = getPathValue(data, key);
+                } else {
+                    value = data;
+                }
+
+                const filter = resolvePathFilter(
+                    pathsToInclude,
+                    pathsToExclude,
+                    key,
+                    item.type === 'container',
+                );
+                if (filter.skip) {
+                    continue;
+                }
+
+                const isOptional = typeof item.options.optional === 'function' ?
+                    item.options.optional(value) :
+                    item.options.optional &&
+                        isOptionalValue(value, item.options.optionalValue);
+
+                if (isOptional) {
+                    if (item.options.optionalInclude) {
+                        output[key] = value;
+                    }
+                    syncPathCount++;
+                    continue;
+                }
+
+                let promise: Promise<unknown>;
+                if (item.type === 'container') {
+                    promise = item.data.run(
+                        isObject(value) ? value : {},
+                        {
+                            group: options.group,
+                            flat: true,
+                            path: pathAbsolute,
+                            pathsToInclude: filter.pathsToInclude,
+                            pathsToExclude: filter.pathsToExclude,
+                            defaults: resolveDefaults(options.defaults, key),
+                            context: options.context,
+                            signal: options.signal,
+                            parallel: true,
+                        },
+                    );
+                } else {
+                    // Wrap sync validators in a microtask so the surrounding
+                    // `Promise.allSettled` always sees a thenable.
+                    const itemData = item.data;
+                    promise = (async () => itemData({
+                        key,
+                        path: pathAbsolute,
+                        value,
+                        data,
+                        group: options.group,
+                        context: options.context as C,
+                        signal: options.signal,
+                    }))();
+                }
+
+                tasks.push({
+                    key,
+                    keyParts,
+                    pathRelative,
+                    promise,
+                    kind: item.type,
+                });
+            }
+
+            if (tasks.length > 0 || syncPathCount > 0) {
+                itemGroups.push({
+                    item, 
+                    tasks, 
+                    syncPathCount, 
+                });
+            }
+        }
+
+        // Wait for all groups concurrently. Promises were already kicked off
+        // eagerly above; this just collects their settled state.
+        const settledByGroup = await Promise.all(itemGroups.map(
+            (group) => Promise.allSettled(group.tasks.map((t) => t.promise)),
+        ));
+
+        let itemCount = 0;
+        let errorCount = 0;
+
+        for (const [i, {
+            item, 
+            tasks, 
+            syncPathCount, 
+        }] of itemGroups.entries()) {
+            const settled = settledByGroup[i];
+
+            let pathFailed = false;
+            for (const [j, task] of tasks.entries()) {
+                const result = settled[j];
+
+                if (result.status === 'fulfilled') {
+                    if (task.kind === 'container') {
+                        const tmp = result.value as Record<string, any>;
+                        const tmpKeys = Object.keys(tmp);
+                        for (const tmpKey of tmpKeys) {
+                            output[this.mergePaths(task.key, tmpKey)] = tmp[tmpKey];
+                        }
+                    } else {
+                        output[task.key] = result.value;
+                    }
+                } else {
+                    this.recordMountError(
+                        result.reason,
+                        item,
+                        task.keyParts,
+                        task.pathRelative,
+                        issues,
+                        options.signal,
+                    );
+                    pathFailed = true;
+                }
+            }
+
+            if (tasks.length + syncPathCount > 0) {
+                itemCount++;
+                if (pathFailed) {
+                    errorCount++;
+                }
+            }
+        }
+
+        return this.finalizeOutput(output, options, issues, errorCount, itemCount);
+    }
+
+    async safeRun(input: Record<string, any> = {}, options: ContainerRunOptions<T, C> = {}): Promise<Result<T>> {
+        try {
+            const data = await this.run(input, options);
+            return { success: true, data };
+        } catch (e) {
+            return this.wrapSafeRunError(e, options);
+        }
+    }
+
+    /**
+     * @throws ValidupError
+     *
+     * Synchronous variant of `run()`. Throws synchronously if any validator
+     * returns a thenable, or if a nested container does not implement
+     * `runSync`. Use it for purely synchronous validator graphs where the
+     * microtask overhead of `await` per mount matters (e.g. driving a
+     * reactive UI without a `pending` flicker).
+     */
+    runSync(
+        data: Record<string, any> = {},
+        options: ContainerRunOptions<T, C> = {},
+    ): T {
+        const { pathsToInclude, pathsToExclude } = this.resolveContainerFilters(options);
+
+        const output: Record<string, any> = {};
+        const issues: Issue[] = [];
+
+        let itemCount = 0;
+        let errorCount = 0;
+
+        for (let i = 0; i < this.items.length; i++) {
+            options.signal?.throwIfAborted();
+
+            const item = this.items[i];
+
+            if (!this.isItemGroupIncluded(item, options.group)) {
+                continue;
+            }
+
+            let pathCount = 0;
+            let pathFailed = false;
+
+            const keys: string[] = item.path ? expandPath(data, item.path) : [''];
+
+            for (const key of keys) {
+                const keyParts = key ? pathToArray(key) : [];
+
+                const pathRelative = keyParts.at(-1);
+                const pathAbsolute = [
+                    ...(options.path ? options.path : []),
+                    ...keyParts,
+                ];
+
+                let value: unknown;
+                if (key.length > 0) {
+                    value = hasOwnProperty(output, key) ?
+                        output[key] :
+                        getPathValue(data, key);
+                } else {
+                    value = data;
+                }
+
+                const filter = resolvePathFilter(
+                    pathsToInclude,
+                    pathsToExclude,
+                    key,
+                    item.type === 'container',
+                );
+                if (filter.skip) {
+                    continue;
+                }
+
+                try {
+                    const isOptional = typeof item.options.optional === 'function' ?
+                        item.options.optional(value) :
+                        item.options.optional &&
+                            isOptionalValue(value, item.options.optionalValue);
+
+                    if (isOptional) {
+                        if (item.options.optionalInclude) {
+                            output[key] = value;
+                        }
+                    } else if (item.type === 'container') {
+                        const childRunSync = (
+                            item.data as IContainer<any, any> & {
+                                runSync?: (...args: any[]) => any
+                            }
+                        ).runSync;
+                        if (typeof childRunSync !== 'function') {
+                            throw new RunSyncViolationError(`runSync: nested container at "${key || '<root>'}" does not implement runSync`);
+                        }
+
+                        const tmp = childRunSync.call(item.data, isObject(value) ? value : {}, {
+                            group: options.group,
+                            flat: true,
+                            path: pathAbsolute,
+                            pathsToInclude: filter.pathsToInclude,
+                            pathsToExclude: filter.pathsToExclude,
+                            defaults: resolveDefaults(options.defaults, key),
+                            context: options.context,
+                            signal: options.signal,
+                        });
+
+                        const tmpKeys = Object.keys(tmp);
+                        for (const tmpKey of tmpKeys) {
+                            output[this.mergePaths(key, tmpKey)] = tmp[tmpKey];
+                        }
+                    } else if (item.type === 'validator') {
+                        const result = item.data({
+                            key,
+                            path: pathAbsolute,
+
+                            value,
+                            data,
+                            group: options.group,
+                            context: options.context as C,
+                            signal: options.signal,
+                        });
+                        if (
+                            result !== null &&
+                            typeof result === 'object' &&
+                            typeof (result as { then?: unknown }).then === 'function'
+                        ) {
+                            throw new RunSyncViolationError(`runSync: validator at "${key || '<root>'}" returned a Promise`);
+                        }
+                        output[key] = result;
+                    }
+                } catch (e) {
+                    this.recordMountError(e, item, keyParts, pathRelative, issues, options.signal);
+                    pathFailed = true;
+                }
+
+                pathCount++;
+            }
+
+            if (pathCount > 0) {
+                itemCount++;
+
+                if (pathFailed) {
+                    errorCount++;
+                }
+            }
+        }
+
+        return this.finalizeOutput(output, options, issues, errorCount, itemCount);
+    }
+
+    safeRunSync(input: Record<string, any> = {}, options: ContainerRunOptions<T, C> = {}): Result<T> {
+        try {
+            const data = this.runSync(input, options);
+            return { success: true, data };
+        } catch (e) {
+            return this.wrapSafeRunError(e, options);
+        }
+    }
+
+    private resolveContainerFilters(options: ContainerRunOptions<T, C>): {
+        pathsToInclude: string[] | undefined,
+        pathsToExclude: string[] | undefined,
+    } {
+        let pathsToInclude: string[] | undefined;
+        if (options.pathsToInclude) {
+            pathsToInclude = options.pathsToInclude as string[];
+        } else if (this.options.pathsToInclude) {
+            pathsToInclude = this.options.pathsToInclude as string[];
+        }
+
+        let pathsToExclude: string[] | undefined;
+        if (options.pathsToExclude) {
+            pathsToExclude = options.pathsToExclude as string[];
+        } else if (this.options.pathsToExclude) {
+            pathsToExclude = this.options.pathsToExclude as string[];
+        }
+
+        return { pathsToInclude, pathsToExclude };
+    }
+
+    /**
+     * Translate a per-mount throw into accumulated `issues`. Re-throws when
+     * the run was aborted (signal-aware validators) so abort errors are not
+     * mangled into validation issues. `keyParts` is the current mount's
+     * expanded path (used to prepend to nested `ValidupError` issues).
+     */
+    private recordMountError(
+        e: unknown,
+        item: Mount<C>,
+        keyParts: PropertyKey[],
+        pathRelative: PropertyKey | undefined,
+        issues: Issue[],
+        signal: AbortSignal | undefined,
+    ): void {
+        if (signal?.aborted) {
+            throw e;
+        }
+        // Structural runSync violations are not validation outcomes — they
+        // mean the caller can't use runSync against this graph. Surface the
+        // diagnostic verbatim instead of wrapping it as "Property X is invalid".
+        if (isRunSyncViolation(e)) {
+            throw e;
+        }
+
+        const childIssues: Issue[] = [];
+
+        if (isValidupError(e)) {
+            for (let i = 0; i < e.issues.length; i++) {
+                const issue = e.issues[i];
+
+                childIssues.push({
+                    ...issue,
+                    path: [
+                        ...keyParts,
+                        ...(issue.path || []),
+                    ],
+                });
+            }
+        } else if (isError(e)) {
+            childIssues.push(defineIssueItem({
+                path: keyParts,
+                message: e.message,
+            }));
+        }
+
+        if (pathRelative) {
+            if (item.type === 'container' || childIssues.length > 1) {
+                issues.push(defineIssueGroup({
+                    message: buildErrorMessageForAttribute(String(pathRelative)),
+                    params: { name: String(pathRelative) },
+                    path: keyParts,
+                    issues: childIssues,
+                }));
+            } else {
+                issues.push(...childIssues);
+            }
+        } else {
+            issues.push(...childIssues);
+        }
+    }
+
+    /**
+     * Apply post-loop semantics: oneOf aggregation, error throw, defaults
+     * fill, and flat-vs-nested output expansion.
+     */
+    private finalizeOutput(
+        output: Record<string, any>,
+        options: ContainerRunOptions<T, C>,
+        issues: Issue[],
+        errorCount: number,
+        itemCount: number,
+    ): T {
         if (this.options.oneOf) {
             if (errorCount === itemCount) {
                 const group = defineIssueGroup({
@@ -390,7 +711,6 @@ export class Container<
                     issues,
                     path: options.path ? options.path : [],
                 });
-
                 throw new ValidupError([group]);
             }
         } else if (errorCount > 0) {
@@ -404,7 +724,7 @@ export class Container<
                     !hasOwnProperty(output, defaultKey) ||
                     typeof output[defaultKey] === 'undefined'
                 ) {
-                    output[defaultKey] = options.defaults[defaultKey as unknown as Path<T>];
+                    output[defaultKey] = (options.defaults as Record<string, any>)[defaultKey];
                 }
             }
         }
@@ -413,43 +733,47 @@ export class Container<
             return output as T;
         }
 
-        const temp : Record<string, any> = {};
-
+        const temp: Record<string, any> = {};
         const keys = Object.keys(output);
         for (const key of keys) {
             setPathValue(temp, key, output[key]);
         }
-
         return temp as T;
     }
 
-    async safeRun(input: Record<string, any> = {}, options: ContainerRunOptions<T> = {}): Promise<Result<T>> {
-        try {
-            const data = await this.run(input, options);
-            return { success: true, data };
-        } catch (e) {
-            if (isValidupError(e)) {
-                return { success: false, error: e };
-            }
-
-            if (isError(e)) {
-                return {
-                    success: false,
-                    error: new ValidupError([
-                        defineIssueItem({
-                            path: [],
-                            message: e.message,
-                        }),
-                    ]),
-                };
-            }
-
-            return { success: false, error: new ValidupError() };
+    private wrapSafeRunError(e: unknown, options: ContainerRunOptions<T, C>): Result<T> {
+        // Abort is not a validation outcome — propagate it. Wrapping it
+        // as a synthetic `Result.failure` would produce a misleading
+        // "AbortError" issue at path `[]`.
+        if (options.signal?.aborted) {
+            throw e;
         }
+        // Same reasoning for `runSync` structural violations.
+        if (isRunSyncViolation(e)) {
+            throw e;
+        }
+
+        if (isValidupError(e)) {
+            return { success: false, error: e };
+        }
+
+        if (isError(e)) {
+            return {
+                success: false,
+                error: new ValidupError([
+                    defineIssueItem({
+                        path: [],
+                        message: e.message,
+                    }),
+                ]),
+            };
+        }
+
+        return { success: false, error: new ValidupError() };
     }
 
     private isItemGroupIncluded(
-        item: Mount,
+        item: Mount<C>,
         group?: string,
     ) : boolean {
         if (group === GroupKey.WILDCARD) {
@@ -481,6 +805,13 @@ export class Container<
         return true;
     }
 
+    /**
+     * Join flat-output keys with `.` separators, preserving any pre-existing
+     * leading dot on the right-hand side. Note: keys containing a *literal*
+     * dot collide with the dotted-path syntax used for nested-output
+     * expansion (see `setPathValue` in `pathtrace`) and will produce
+     * ambiguous output when re-expanded — avoid mounting/returning such keys.
+     */
     private mergePaths(...args: (string | undefined)[]) {
         let output : string = '';
 

--- a/packages/validup/src/container/run-sync-violation.ts
+++ b/packages/validup/src/container/run-sync-violation.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Thrown by `Container.runSync` when a validator returns a Promise or a
+ * nested container does not implement `runSync`. Marked separately from
+ * generic `Error` so the per-mount catch can re-throw it instead of folding
+ * it into the issue list (otherwise users would get "Property X is invalid"
+ * instead of the structural diagnostic).
+ *
+ * Internal — not exported from the package barrel.
+ */
+export class RunSyncViolationError extends Error {
+    override readonly name = 'RunSyncViolationError';
+}
+
+/**
+ * Duck-typed check — robust against `instanceof` mismatches when a duplicate
+ * copy of the package exists in the dependency tree, or when the throw
+ * crosses a realm boundary. Mirrors the `isValidupError` pattern.
+ */
+export function isRunSyncViolation(e: unknown): e is RunSyncViolationError {
+    if (e instanceof RunSyncViolationError) {
+        return true;
+    }
+    return (
+        typeof e === 'object' &&
+        e !== null &&
+        (e as { name?: unknown }).name === 'RunSyncViolationError'
+    );
+}

--- a/packages/validup/src/container/types.ts
+++ b/packages/validup/src/container/types.ts
@@ -36,6 +36,7 @@ export type ContainerOptions<T> = {
 
 export type ContainerRunOptions<
     T extends Record<string, any> = Record<string, any>,
+    C = unknown,
 > = {
     /**
      * Default values for the container output.
@@ -71,6 +72,35 @@ export type ContainerRunOptions<
      * be considered for execution.
      */
     pathsToExclude?: Path<T>[]
+
+    /**
+     * Caller-supplied context surfaced on `ValidatorContext.context`. Forwarded
+     * unchanged into nested container `run()` calls so the entire tree shares
+     * the same value.
+     */
+    context?: C,
+
+    /**
+     * Cancellation signal. The container checks `signal.aborted` between
+     * mounts and rethrows `signal.reason` when set. Forwarded unchanged into
+     * nested `run()` calls and surfaced on `ValidatorContext.signal` so async
+     * validators can pass it into `fetch`, DB drivers, etc.
+     */
+    signal?: AbortSignal,
+
+    /**
+     * Run mounted validators / nested containers concurrently rather than
+     * sequentially. Useful when several independent fields hit slow async
+     * resources (DB lookups, HTTP calls). Forwarded unchanged into nested
+     * `run()` calls.
+     *
+     * Trade-off: in parallel mode each mount captures its `value` from the
+     * input `data` *before* any other mount runs, so a later mount can no
+     * longer read an earlier mount's transformed `output[key]`. Use
+     * sequential mode (the default) for chained-key sanitize-then-validate
+     * patterns.
+     */
+    parallel?: boolean
 };
 
 export type MountOptions = {
@@ -83,9 +113,13 @@ export type MountOptions = {
      * Specify if an optional value is also acceptable for the mount key.
      * An optional value won't be passed to the underlying container/validator.
      *
+     * Pass a predicate `(value) => boolean` for fine-grained control beyond
+     * what `optionalValue` covers (e.g. "treat empty string as missing but
+     * keep `0`"). When a predicate is provided, `optionalValue` is ignored.
+     *
      * default: false
      */
-    optional?: boolean,
+    optional?: boolean | ((value: unknown) => boolean),
 
     /**
      * Which values are considered optional.
@@ -117,7 +151,7 @@ export type ResultFailure = {
 
 export type Result<T extends ObjectLiteral = ObjectLiteral> = ResultSuccess<T> | ResultFailure;
 
-export interface IContainer<T extends ObjectLiteral = ObjectLiteral> {
+export interface IContainer<T extends ObjectLiteral = ObjectLiteral, C = unknown> {
     /**
      * Run container with given input.
      *
@@ -126,7 +160,7 @@ export interface IContainer<T extends ObjectLiteral = ObjectLiteral> {
      */
     run(
         input?: Record<string, any>,
-        options?: ContainerRunOptions<T>,
+        options?: ContainerRunOptions<T, C>,
     ): Promise<T>
 
     /**
@@ -137,23 +171,54 @@ export interface IContainer<T extends ObjectLiteral = ObjectLiteral> {
      */
     safeRun(
         input?: Record<string, any>,
-        options?: ContainerRunOptions<T>,
+        options?: ContainerRunOptions<T, C>,
     ): Promise<Result<T>>
+
+    /**
+     * Synchronous variant of `run()`. Optional — implementations can omit
+     * this when their validators are inherently async. The default
+     * `Container` provides it; nested containers without it cannot be
+     * traversed by a parent's `runSync`.
+     */
+    runSync?(
+        input?: Record<string, any>,
+        options?: ContainerRunOptions<T, C>,
+    ): T
+
+    /**
+     * Synchronous variant of `safeRun()`. Optional — same caveat as `runSync`.
+     */
+    safeRunSync?(
+        input?: Record<string, any>,
+        options?: ContainerRunOptions<T, C>,
+    ): Result<T>
 }
 
 export type BaseMount = {
     options: MountOptions,
+    /**
+     * Mount path expressed in dot/bracket notation (e.g. `foo.bar`,
+     * `items[0].name`). Path segments are joined and split on `.` throughout
+     * the runtime, so keys that contain a *literal* dot (e.g. an object keyed
+     * `data['user.email']`) are not addressable as a single mount segment and
+     * will produce ambiguous flat output when merged. Use bracketed/array
+     * shapes instead for inputs that contain literal-dot keys.
+     */
     path?: string,
 };
 
 export type ContainerMount = BaseMount & {
     type: 'container',
-    data: IContainer,
+    // Child containers carry their own context type; the parent's context
+    // value is forwarded unchanged at run time. We don't constrain the child's
+    // C parameter here — variance through the discriminated union is awkward
+    // and the practical contract is "whatever the parent has, pass it through".
+    data: IContainer<any, any>,
 };
 
-export type ValidatorMount = BaseMount & {
+export type ValidatorMount<C = unknown> = BaseMount & {
     type: 'validator',
-    data: Validator
+    data: Validator<C>
 };
 
-export type Mount = ContainerMount | ValidatorMount;
+export type Mount<C = unknown> = ContainerMount | ValidatorMount<C>;

--- a/packages/validup/src/error/base.ts
+++ b/packages/validup/src/error/base.ts
@@ -1,20 +1,28 @@
 /*
- * Copyright (c) 2024-2024.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { BaseError } from '@ebec/core';
 import { buildErrorMessageForAttributes, stringifyPath } from '../helpers';
 import type { Issue } from '../issue';
 
-export class ValidupError extends Error {
+export class ValidupError extends BaseError {
     readonly issues: Issue[];
 
     constructor(issues: Issue[] = []) {
         const paths = issues.map((issue) => stringifyPath(issue.path));
-        super(buildErrorMessageForAttributes(paths));
+        super({ message: buildErrorMessageForAttributes(paths) });
 
         this.issues = issues;
+    }
+
+    override toJSON(): ReturnType<BaseError['toJSON']> & { issues: Issue[] } {
+        return {
+            ...super.toJSON(),
+            issues: this.issues,
+        };
     }
 }

--- a/packages/validup/src/error/check.ts
+++ b/packages/validup/src/error/check.ts
@@ -10,11 +10,20 @@ import { hasOwnProperty, isObject } from '../utils';
 import { ValidupError } from './base';
 
 export function isError(input: unknown) : input is Error & { [key: string]: any } {
+    // Primary check: anything that walks like an Error in this realm.
+    // Keeps cross-realm fallbacks (e.g. errors from another iframe / vm
+    // context where `instanceof Error` is false) duck-typed via the
+    // `message` shape — which also matches `ValidupError`-shaped throws
+    // from a duplicate copy of the package.
+    if (input instanceof Error) {
+        return true;
+    }
+
     if (!isObject(input)) {
         return false;
     }
 
-    return typeof input.message === 'string';
+    return typeof input.message === 'string' && typeof input.name === 'string';
 }
 
 export function isValidupError(error: unknown) : error is ValidupError {

--- a/packages/validup/src/helpers/defaults.ts
+++ b/packages/validup/src/helpers/defaults.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Slice a parent `defaults` map down to entries that target paths inside a
+ * single nested container mount, with the mount-key prefix stripped so the
+ * child sees them as local keys. Exact-key matches (the default targets the
+ * mount root itself) are skipped — the parent's post-loop fill handles those
+ * once the child has returned, since the child is run with `flat: true` and
+ * cannot address its own root.
+ */
+export function resolveDefaults(
+    defaults: Record<string, any> | undefined,
+    key: string,
+): Record<string, any> | undefined {
+    if (typeof defaults === 'undefined') {
+        return undefined;
+    }
+    if (key.length === 0) {
+        return defaults;
+    }
+
+    const output: Record<string, any> = {};
+    let matched = false;
+    const keys = Object.keys(defaults);
+    for (const k of keys) {
+        if (k.startsWith(`${key}.`)) {
+            output[k.slice(key.length + 1)] = defaults[k];
+            matched = true;
+        }
+    }
+    return matched ? output : undefined;
+}

--- a/packages/validup/src/helpers/path-filter.ts
+++ b/packages/validup/src/helpers/path-filter.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type PathFilterResolution = {
+    skip: boolean,
+    pathsToInclude: string[] | undefined,
+    pathsToExclude: string[] | undefined,
+};
+
+/**
+ * Resolve `pathsToInclude` / `pathsToExclude` against a single mounted item's
+ * (already-expanded) local `key`. Returns whether to skip the item, plus the
+ * filter sub-lists to forward into a child container — with the parent prefix
+ * stripped so the child can match purely against its own local keys.
+ *
+ * Semantics:
+ * - Un-keyed container mount (`key === ''`) shares the parent's namespace, so
+ *   filters are forwarded verbatim.
+ * - Exact match in `pathsToInclude` / `pathsToExclude` matches the whole mount.
+ * - Prefix match (`<key>.…`) only descends into container mounts; leaf
+ *   validators with deeper-target filters fall through (skipped for include,
+ *   kept for exclude).
+ */
+export function resolvePathFilter(
+    pathsToInclude: string[] | undefined,
+    pathsToExclude: string[] | undefined,
+    key: string,
+    isContainer: boolean,
+): PathFilterResolution {
+    if (key.length === 0) {
+        return {
+            skip: false,
+            pathsToInclude,
+            pathsToExclude,
+        };
+    }
+
+    let includeForward: string[] | undefined;
+    if (typeof pathsToInclude !== 'undefined') {
+        let exact = false;
+        const stripped: string[] = [];
+        for (const path of pathsToInclude) {
+            if (path === key) {
+                exact = true;
+            } else if (isContainer && path.startsWith(`${key}.`)) {
+                stripped.push(path.slice(key.length + 1));
+            }
+        }
+        if (exact) {
+            includeForward = undefined;
+        } else if (stripped.length > 0) {
+            includeForward = stripped;
+        } else {
+            return {
+                skip: true,
+                pathsToInclude: undefined,
+                pathsToExclude: undefined,
+            };
+        }
+    }
+
+    let excludeForward: string[] | undefined;
+    if (typeof pathsToExclude !== 'undefined') {
+        const stripped: string[] = [];
+        for (const path of pathsToExclude) {
+            if (path === key) {
+                return {
+                    skip: true,
+                    pathsToInclude: undefined,
+                    pathsToExclude: undefined,
+                };
+            }
+            if (isContainer && path.startsWith(`${key}.`)) {
+                stripped.push(path.slice(key.length + 1));
+            }
+        }
+        if (stripped.length > 0) {
+            excludeForward = stripped;
+        }
+    }
+
+    return {
+        skip: false,
+        pathsToInclude: includeForward,
+        pathsToExclude: excludeForward,
+    };
+}

--- a/packages/validup/src/issue/constants.ts
+++ b/packages/validup/src/issue/constants.ts
@@ -5,8 +5,29 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export enum IssueCode {
-    VALUE_INVALID = 'value_invalid',
-
-    ONE_OF_FAILED = 'one_of_failed',
+/**
+ * Registry of well-known issue codes. Third-party packages can extend the
+ * union via TypeScript declaration merging:
+ *
+ * ```ts
+ * declare module 'validup' {
+ *     interface IssueCodeRegistry {
+ *         email_taken: 'email_taken';
+ *     }
+ * }
+ * ```
+ *
+ * After augmentation, `IssueCode` widens to include the new literal so
+ * `defineIssueItem({ code: 'email_taken', ... })` is type-checked.
+ */
+export interface IssueCodeRegistry {
+    VALUE_INVALID: 'value_invalid',
+    ONE_OF_FAILED: 'one_of_failed',
 }
+
+export type IssueCode = IssueCodeRegistry[keyof IssueCodeRegistry];
+
+export const IssueCode = {
+    VALUE_INVALID: 'value_invalid',
+    ONE_OF_FAILED: 'one_of_failed',
+} as const satisfies { [K in keyof IssueCodeRegistry]: IssueCodeRegistry[K] };

--- a/packages/validup/src/issue/flatten.ts
+++ b/packages/validup/src/issue/flatten.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isIssueGroup, isIssueItem } from './check';
+import type { Issue, IssueGroup, IssueItem } from './types';
+
+export function flattenIssueItems(issues: Issue[]): IssueItem[] {
+    const output: IssueItem[] = [];
+    for (const issue of issues) {
+        if (isIssueItem(issue)) {
+            output.push(issue);
+        } else {
+            output.push(...flattenIssueItems(issue.issues));
+        }
+    }
+    return output;
+}
+
+export function flattenIssueGroups(issues: Issue[]): IssueGroup[] {
+    const output: IssueGroup[] = [];
+    for (const issue of issues) {
+        if (isIssueGroup(issue)) {
+            output.push(issue);
+            output.push(...flattenIssueGroups(issue.issues));
+        }
+    }
+    return output;
+}

--- a/packages/validup/src/issue/format.ts
+++ b/packages/validup/src/issue/format.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { interpolate } from '@ebec/core';
+import type { IssueCode } from './constants';
+import type { Issue } from './types';
+
+/**
+ * Map of issue `code` → message template. Templates use `{name}` placeholders
+ * — the same syntax `@ebec/core`'s `interpolate` understands — and are
+ * resolved against `Issue.params` at format time.
+ *
+ * ```ts
+ * const de: IssueMessageTemplates = {
+ *     value_invalid: 'Wert ist ungültig',
+ *     one_of_failed: 'Keine der Varianten war erfolgreich',
+ * };
+ * ```
+ */
+export type IssueMessageTemplates = Partial<Record<IssueCode, string>> & Record<string, string>;
+
+/**
+ * Render an issue's user-facing message.
+ *
+ * Resolution order:
+ * 1. If `templates[code]` exists, return `interpolate(template, issue.params)`.
+ * 2. Else return `issue.message` (the default English rendering set at
+ *    construction time).
+ * 3. Else return `fallback`.
+ */
+export function formatIssue(
+    issue: Issue,
+    templates?: IssueMessageTemplates,
+    fallback: string = '',
+): string {
+    if (templates && issue.code) {
+        const template = templates[issue.code];
+        if (typeof template === 'string') {
+            return interpolate(template, issue.params || {});
+        }
+    }
+    if (typeof issue.message === 'string' && issue.message.length > 0) {
+        return issue.message;
+    }
+    return fallback;
+}
+
+// Re-export ebec's `interpolate` so consumers writing custom formatters don't
+// need a direct dependency on `@ebec/core`. Same `{name}` placeholder syntax.
+export { interpolate } from '@ebec/core';

--- a/packages/validup/src/issue/index.ts
+++ b/packages/validup/src/issue/index.ts
@@ -8,4 +8,6 @@
 export * from './check';
 export * from './constants';
 export * from './define';
+export * from './flatten';
+export * from './format';
 export * from './types';

--- a/packages/validup/src/issue/types.ts
+++ b/packages/validup/src/issue/types.ts
@@ -5,6 +5,8 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+import type { IssueCode } from './constants';
+
 export interface IssueBase {
 
     /**
@@ -18,16 +20,27 @@ export interface IssueBase {
     path: PropertyKey[],
 
     /**
-     * Issue message.
+     * Default-rendered message (eager, English). Use `formatIssue` with a
+     * `code → template` map for localized re-rendering at the consumer side.
      */
-    message: string
+    message: string,
+
+    /**
+     * Structured parameters used by the default `message` rendering and
+     * available to consumer-side formatters (i18n, custom locales). For
+     * built-in issues created by the runtime, `params` is populated where
+     * the message references a non-trivial value (e.g. attribute name).
+     */
+    params?: Record<string, unknown>
 }
 
 export interface IssueItem extends IssueBase {
     /**
-     * Code identifying the issue
+     * Code identifying the issue. Known codes come from `IssueCodeRegistry`
+     * (extensible via declaration merging); the `string` widening leaves the
+     * door open for ad-hoc codes that don't need a registry entry.
      */
-    code: string,
+    code: IssueCode | (string & {}),
 
     /**
      * Issue Type
@@ -47,9 +60,10 @@ export interface IssueItem extends IssueBase {
 
 export interface IssueGroup extends IssueBase {
     /**
-     * Code identifying the issue
+     * Code identifying the issue. See `IssueItem.code` for the registry
+     * extension mechanism.
      */
-    code?: string,
+    code?: IssueCode | (string & {}),
 
     /**
      * Issue Type

--- a/packages/validup/src/types.ts
+++ b/packages/validup/src/types.ts
@@ -7,7 +7,7 @@
 
 export type ObjectLiteral = Record<string | number, any>;
 
-export type ValidatorContext = {
+export type ValidatorContext<C = unknown> = {
     /**
      * The expanded mount path in the current container.
      */
@@ -31,7 +31,22 @@ export type ValidatorContext = {
     /**
      * The group name for which the validator is executed.
      */
-    group?: string
+    group?: string,
+
+    /**
+     * Caller-supplied context, forwarded unchanged through nested containers.
+     * Useful for request-scoped data (current user, locale, DB connection,
+     * request id) that validators need but isn't part of the validated value.
+     */
+    context: C,
+
+    /**
+     * Cancellation signal forwarded from `ContainerRunOptions.signal`.
+     * Async validators (DB lookups, HTTP fetches) should pass it through to
+     * cancel I/O when the run is aborted. The container itself checks
+     * `signal.aborted` between mounts and rethrows the signal's `reason`.
+     */
+    signal?: AbortSignal
 };
 
-export type Validator = (ctx: ValidatorContext) => Promise<unknown> | unknown;
+export type Validator<C = unknown> = (ctx: ValidatorContext<C>) => Promise<unknown> | unknown;

--- a/packages/validup/test/unit/abort-signal.spec.ts
+++ b/packages/validup/test/unit/abort-signal.spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Validator } from '../../src';
+import { Container } from '../../src';
+
+describe('container abort-signal propagation', () => {
+    it('should expose ctx.signal to validators', async () => {
+        const seen: (AbortSignal | undefined)[] = [];
+
+        const container = new Container<{ foo: string }>();
+        const validator: Validator = (ctx) => {
+            seen.push(ctx.signal);
+            return ctx.value;
+        };
+        container.mount('foo', validator);
+
+        const controller = new AbortController();
+        await container.run({ foo: 'bar' }, { signal: controller.signal });
+
+        expect(seen).toHaveLength(1);
+        expect(seen[0]).toBe(controller.signal);
+    });
+
+    it('should not break runs when no signal is supplied', async () => {
+        const seen: (AbortSignal | undefined)[] = [];
+
+        const container = new Container<{ foo: string }>();
+        const validator: Validator = (ctx) => {
+            seen.push(ctx.signal);
+            return ctx.value;
+        };
+        container.mount('foo', validator);
+
+        await container.run({ foo: 'bar' });
+
+        expect(seen).toEqual([undefined]);
+    });
+
+    it('should short-circuit between mounts when aborted', async () => {
+        const calls: string[] = [];
+        const controller = new AbortController();
+
+        const container = new Container<{ foo: string, bar: string }>();
+        container.mount('foo', (ctx) => {
+            calls.push('foo');
+            controller.abort();
+            return ctx.value;
+        });
+        container.mount('bar', (ctx) => {
+            calls.push('bar');
+            return ctx.value;
+        });
+
+        expect.assertions(2);
+        try {
+            await container.run({ foo: 'a', bar: 'b' }, { signal: controller.signal });
+        } catch (e) {
+            expect((e as Error).name).toEqual('AbortError');
+        }
+
+        expect(calls).toEqual(['foo']);
+    });
+
+    it('should rethrow validator-side aborts instead of wrapping them as issues', async () => {
+        const controller = new AbortController();
+
+        const container = new Container<{ foo: string }>();
+        container.mount('foo', async (ctx) => {
+            controller.abort(new Error('cancelled'));
+            ctx.signal?.throwIfAborted();
+            return ctx.value;
+        });
+
+        expect.assertions(1);
+        try {
+            await container.run({ foo: 'a' }, { signal: controller.signal });
+        } catch (e) {
+            expect((e as Error).message).toEqual('cancelled');
+        }
+    });
+
+    it('should forward signal into nested containers', async () => {
+        const childSeen: (AbortSignal | undefined)[] = [];
+
+        const child = new Container<{ inner: string }>();
+        child.mount('inner', (ctx) => {
+            childSeen.push(ctx.signal);
+            return ctx.value;
+        });
+
+        const parent = new Container<{ nested: { inner: string } }>();
+        parent.mount('nested', child);
+
+        const controller = new AbortController();
+        await parent.run(
+            { nested: { inner: 'x' } },
+            { signal: controller.signal },
+        );
+
+        expect(childSeen).toHaveLength(1);
+        expect(childSeen[0]).toBe(controller.signal);
+    });
+
+    it('should rethrow abort from safeRun instead of returning a failure result', async () => {
+        const controller = new AbortController();
+
+        const container = new Container<{ foo: string, bar: string }>();
+        container.mount('foo', (ctx) => {
+            controller.abort();
+            return ctx.value;
+        });
+        container.mount('bar', (ctx) => ctx.value);
+
+        expect.assertions(1);
+        try {
+            await container.safeRun({ foo: 'a', bar: 'b' }, { signal: controller.signal });
+        } catch (e) {
+            expect((e as Error).name).toEqual('AbortError');
+        }
+    });
+});

--- a/packages/validup/test/unit/context.spec.ts
+++ b/packages/validup/test/unit/context.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Validator } from '../../src';
+import { Container } from '../../src';
+
+describe('container context propagation', () => {
+    type AppContext = { userId: string };
+
+    it('should expose run-time context on ValidatorContext', async () => {
+        const seen: unknown[] = [];
+
+        const container = new Container<{ foo: string }, AppContext>();
+        const validator: Validator<AppContext> = (ctx) => {
+            seen.push(ctx.context);
+            return ctx.value;
+        };
+        container.mount('foo', validator);
+
+        await container.run({ foo: 'bar' }, { context: { userId: 'u-1' } });
+
+        expect(seen).toEqual([{ userId: 'u-1' }]);
+    });
+
+    it('should default ctx.context to undefined when no context is passed', async () => {
+        const seen: unknown[] = [];
+
+        const container = new Container<{ foo: string }>();
+        const validator: Validator = (ctx) => {
+            seen.push(ctx.context);
+            return ctx.value;
+        };
+        container.mount('foo', validator);
+
+        await container.run({ foo: 'bar' });
+
+        expect(seen).toEqual([undefined]);
+    });
+
+    it('should forward context unchanged into nested containers', async () => {
+        const seen: unknown[] = [];
+
+        const child = new Container<{ inner: string }, AppContext>();
+        const childValidator: Validator<AppContext> = (ctx) => {
+            seen.push(ctx.context);
+            return ctx.value;
+        };
+        child.mount('inner', childValidator);
+
+        const parent = new Container<{ nested: { inner: string } }, AppContext>();
+        parent.mount('nested', child);
+
+        const ctx: AppContext = { userId: 'u-2' };
+        await parent.run(
+            { nested: { inner: 'value' } },
+            { context: ctx },
+        );
+
+        expect(seen).toEqual([ctx]);
+    });
+
+    it('should pass context into safeRun', async () => {
+        const seen: unknown[] = [];
+
+        const container = new Container<{ foo: string }, AppContext>();
+        const validator: Validator<AppContext> = (ctx) => {
+            seen.push(ctx.context);
+            return ctx.value;
+        };
+        container.mount('foo', validator);
+
+        const result = await container.safeRun(
+            { foo: 'bar' },
+            { context: { userId: 'u-3' } },
+        );
+
+        expect(result.success).toBe(true);
+        expect(seen).toEqual([{ userId: 'u-3' }]);
+    });
+});

--- a/packages/validup/test/unit/error.spec.ts
+++ b/packages/validup/test/unit/error.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { ValidupError, defineIssueGroup, isValidupError } from '../../src';
 
 describe('error', () => {
@@ -31,5 +32,27 @@ describe('error', () => {
         const error = new Error();
 
         expect(isValidupError(error)).toBeFalsy();
+    });
+
+    it('should expose an ebec-style code on ValidupError', () => {
+        const error = new ValidupError();
+
+        expect(error.code).toEqual('VALIDUP_ERROR');
+    });
+
+    it('should serialize via toJSON including issues', () => {
+        const error = new ValidupError([
+            defineIssueGroup({
+                message: 'foo',
+                issues: [],
+                path: ['foo'],
+            }),
+        ]);
+
+        const serialized = error.toJSON();
+        expect(serialized.name).toEqual('ValidupError');
+        expect(serialized.code).toEqual('VALIDUP_ERROR');
+        expect(serialized.issues).toHaveLength(1);
+        expect(serialized.issues[0]).toMatchObject({ type: 'group', message: 'foo' });
     });
 });

--- a/packages/validup/test/unit/format.spec.ts
+++ b/packages/validup/test/unit/format.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    Container,
+    IssueCode,
+    ValidupError,
+    defineIssueGroup,
+    defineIssueItem,
+    formatIssue,
+    interpolate,
+} from '../../src';
+import { stringValidator } from '../data';
+
+describe('formatIssue', () => {
+    it('should fall back to issue.message when no templates are provided', () => {
+        const issue = defineIssueItem({ path: ['x'], message: 'invalid' });
+        expect(formatIssue(issue)).toEqual('invalid');
+    });
+
+    it('should interpolate a matching template using params', () => {
+        const issue = defineIssueItem({
+            code: IssueCode.VALUE_INVALID,
+            path: ['email'],
+            message: 'Value invalid',
+            params: { name: 'email' },
+        });
+
+        const out = formatIssue(issue, { value_invalid: 'Field {name} is invalid' });
+
+        expect(out).toEqual('Field email is invalid');
+    });
+
+    it('should fall back to message when no template matches the code', () => {
+        const issue = defineIssueItem({
+            code: 'unknown_code',
+            path: [],
+            message: 'literal',
+        });
+
+        expect(formatIssue(issue, { value_invalid: 'X' })).toEqual('literal');
+    });
+
+    it('should return the fallback when neither template nor message is set', () => {
+        const issue = defineIssueGroup({
+            path: [],
+            message: '',
+            issues: [],
+        });
+
+        expect(formatIssue(issue, undefined, '—')).toEqual('—');
+    });
+
+    it('should re-export ebec interpolate', () => {
+        expect(interpolate('hello {who}', { who: 'world' })).toEqual('hello world');
+    });
+});
+
+describe('Issue.params populated by the runtime', () => {
+    it('should set params: { name } on the wrapping IssueGroup of a failing mount', async () => {
+        const child = new Container<{ inner: string }>();
+        child.mount('inner', stringValidator);
+
+        const parent = new Container<{ profile: { inner: string } }>();
+        parent.mount('profile', child);
+
+        try {
+            await parent.run({ profile: { inner: 42 } });
+            expect.fail('expected ValidupError');
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                const [group] = e.issues;
+                expect(group?.type).toEqual('group');
+                if (group?.type === 'group') {
+                    expect(group.params).toEqual({ name: 'profile' });
+                }
+            }
+        }
+    });
+});

--- a/packages/validup/test/unit/group.spec.ts
+++ b/packages/validup/test/unit/group.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { Container } from '../../src';
 import { stringValidator } from '../data';
 

--- a/packages/validup/test/unit/initialize.spec.ts
+++ b/packages/validup/test/unit/initialize.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { Container } from '../../src';
 import { stringValidator } from '../data';
 

--- a/packages/validup/test/unit/issue.spec.ts
+++ b/packages/validup/test/unit/issue.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import type { IssueGroup, IssueItem } from '../../src';
 import {
     IssueCode,

--- a/packages/validup/test/unit/module.spec.ts
+++ b/packages/validup/test/unit/module.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import type { Validator } from '../../src';
 import { Container } from '../../src';
 
@@ -56,6 +57,50 @@ describe('src/module', () => {
 
         outcome = await container.run({}, { defaults: { foo: 'boz' } });
         expect(outcome.foo).toEqual('boz');
+    });
+
+    it('should forward sliced defaults into nested containers', async () => {
+        const childOptionsSeen: any[] = [];
+        const child = {
+            run: (async (input: any, opts: any = {}) => {
+                childOptionsSeen.push(opts);
+                return input;
+            }),
+            safeRun: (async () => ({ success: true, data: {} })),
+        };
+
+        const parent = new Container<{ nested: Record<string, unknown>, top: string }>();
+        parent.mount('nested', child as any);
+
+        await parent.run(
+            { nested: {} },
+            {
+                defaults: {
+                    'nested.foo': 'x',
+                    'nested.deep.bar': 'y',
+                    top: 'z',
+                } as any,
+            },
+        );
+
+        expect(childOptionsSeen).toHaveLength(1);
+        expect(childOptionsSeen[0].defaults).toEqual({
+            foo: 'x',
+            'deep.bar': 'y',
+        });
+    });
+
+    it('should fill nested defaults into the expanded output', async () => {
+        const child = new Container<{ foo: string }>();
+        const parent = new Container<{ nested: { foo: string } }>();
+        parent.mount('nested', child);
+
+        const outcome = await parent.run(
+            {},
+            { defaults: { 'nested.foo': 'fallback' } as any },
+        );
+
+        expect(outcome.nested?.foo).toEqual('fallback');
     });
 
     it('should not validate', async () => {

--- a/packages/validup/test/unit/mount-key.spec.ts
+++ b/packages/validup/test/unit/mount-key.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import type { ValidatorContext } from '../../src';
 import { Container } from '../../src';
 

--- a/packages/validup/test/unit/one-of.spec.ts
+++ b/packages/validup/test/unit/one-of.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { Container, ValidupError } from '../../src';
 import { stringValidator } from '../data';
 

--- a/packages/validup/test/unit/optional.spec.ts
+++ b/packages/validup/test/unit/optional.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { Container, OptionalValue } from '../../src';
 import { stringValidator } from '../data';
 
@@ -172,5 +173,38 @@ describe('optional', () => {
         } catch (e) {
             expect(e).toBeDefined();
         }
+    });
+
+    it('should treat empty string as missing via predicate while keeping 0', async () => {
+        // Predicate use case the FALSY enum can't express: drop empty strings,
+        // keep numeric zeros (0 must reach the validator).
+        const container = new Container<{ name: string, count: number }>();
+        container.mount(
+            'name',
+            { optional: (v) => v === '' || typeof v === 'undefined' },
+            stringValidator,
+        );
+        container.mount('count', (ctx) => {
+            if (typeof ctx.value !== 'number') {
+                throw new Error('Value is not a number');
+            }
+            return ctx.value;
+        });
+
+        const output = await container.run({ name: '', count: 0 });
+        expect(output.name).toBeUndefined();
+        expect(output.count).toEqual(0);
+    });
+
+    it('should pass through optionalInclude with a predicate', async () => {
+        const container = new Container<{ tag: string }>();
+        container.mount(
+            'tag',
+            { optional: (v) => typeof v !== 'string', optionalInclude: true },
+            stringValidator,
+        );
+
+        const output = await container.run({ tag: 42 } as any);
+        expect(output.tag).toEqual(42);
     });
 });

--- a/packages/validup/test/unit/parallel.spec.ts
+++ b/packages/validup/test/unit/parallel.spec.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Validator } from '../../src';
+import { Container, ValidupError } from '../../src';
+
+describe('Container.run parallel mode', () => {
+    it('should run independent async validators concurrently', async () => {
+        // Each validator stalls for 30ms; sequential = 60ms+, parallel ≈ 30ms.
+        const slow = (delay: number, label: string): Validator => async () => {
+            await new Promise((r) => {
+                setTimeout(r, delay);
+            });
+            return label;
+        };
+
+        const container = new Container<{ a: string, b: string }>();
+        container.mount('a', slow(30, 'A'));
+        container.mount('b', slow(30, 'B'));
+
+        const start = Date.now();
+        const out = await container.run({ a: 1, b: 1 }, { parallel: true });
+        const elapsed = Date.now() - start;
+
+        expect(out.a).toEqual('A');
+        expect(out.b).toEqual('B');
+        // Allow generous slack for slow CI; sequential would be >= 60ms.
+        expect(elapsed).toBeLessThan(55);
+    });
+
+    it('should aggregate failures from all parallel validators', async () => {
+        const failing: Validator = async () => {
+            throw new Error('boom');
+        };
+
+        const container = new Container<{ a: string, b: string }>();
+        container.mount('a', failing);
+        container.mount('b', failing);
+
+        try {
+            await container.run({ a: 1, b: 1 }, { parallel: true });
+            expect.fail('expected ValidupError');
+        } catch (e) {
+            expect(e).toBeInstanceOf(ValidupError);
+            if (e instanceof ValidupError) {
+                expect(e.issues).toHaveLength(2);
+            }
+        }
+    });
+
+    it('should preserve registration order when issuing failures', async () => {
+        const failingFirst: Validator = async () => {
+            await new Promise<void>((r) => {
+                setTimeout(r, 20);
+            });
+            throw new Error('first');
+        };
+        const failingSecond: Validator = async () => {
+            // Resolves earlier than first, but should still come second
+            // in `issues[]` because `a` was registered first.
+            throw new Error('second');
+        };
+
+        const container = new Container<{ a: string, b: string }>();
+        container.mount('a', failingFirst);
+        container.mount('b', failingSecond);
+
+        try {
+            await container.run({ a: 1, b: 1 }, { parallel: true });
+            expect.fail('expected ValidupError');
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                expect(e.issues[0]?.path).toEqual(['a']);
+                expect(e.issues[1]?.path).toEqual(['b']);
+            }
+        }
+    });
+
+    it('should propagate abort across parallel mounts', async () => {
+        const controller = new AbortController();
+        const stallable: Validator = async (ctx) => {
+            await new Promise((resolve, reject) => {
+                const t = setTimeout(resolve, 100);
+                ctx.signal?.addEventListener('abort', () => {
+                    clearTimeout(t);
+                    reject(ctx.signal!.reason);
+                });
+            });
+            return ctx.value;
+        };
+
+        const container = new Container<{ a: string, b: string }>();
+        container.mount('a', stallable);
+        container.mount('b', stallable);
+
+        setTimeout(() => controller.abort(), 10);
+
+        try {
+            await container.run({ a: 1, b: 1 }, { parallel: true, signal: controller.signal });
+            expect.fail('expected abort');
+        } catch (e) {
+            expect((e as Error).name).toEqual('AbortError');
+        }
+    });
+
+    it('should forward parallel into nested containers', async () => {
+        const seenOptions: any[] = [];
+        const child = {
+            run: async (input: any, opts: any = {}) => {
+                seenOptions.push(opts);
+                return input;
+            },
+            safeRun: async () => ({ success: true, data: {} }),
+        };
+
+        const parent = new Container<{ nested: Record<string, unknown> }>();
+        parent.mount('nested', child as any);
+
+        await parent.run({ nested: {} }, { parallel: true });
+
+        expect(seenOptions).toHaveLength(1);
+        expect(seenOptions[0].parallel).toBe(true);
+    });
+
+    it('should still honor oneOf in parallel mode', async () => {
+        const fail: Validator = async () => {
+            throw new Error('nope');
+        };
+        const ok: Validator = async (ctx) => ctx.value;
+
+        const container = new Container<{ a: string, b: string }>({ oneOf: true });
+        container.mount('a', fail);
+        container.mount('b', ok);
+
+        const out = await container.run({ a: 1, b: 'good' }, { parallel: true });
+        expect(out.b).toEqual('good');
+    });
+
+    it('should still honor group filtering in parallel mode', async () => {
+        const seen: string[] = [];
+        const tag = (name: string): Validator => async (ctx) => {
+            seen.push(name);
+            return ctx.value;
+        };
+
+        const container = new Container<{ a: string, b: string }>();
+        container.mount('a', { group: 'create' }, tag('a'));
+        container.mount('b', { group: 'update' }, tag('b'));
+
+        await container.run({ a: 1, b: 1 }, { parallel: true, group: 'create' });
+
+        expect(seen).toEqual(['a']);
+    });
+});

--- a/packages/validup/test/unit/parallel.spec.ts
+++ b/packages/validup/test/unit/parallel.spec.ts
@@ -11,26 +11,51 @@ import { Container, ValidupError } from '../../src';
 
 describe('Container.run parallel mode', () => {
     it('should run independent async validators concurrently', async () => {
-        // Each validator stalls for 30ms; sequential = 60ms+, parallel ≈ 30ms.
-        const slow = (delay: number, label: string): Validator => async () => {
-            await new Promise((r) => {
-                setTimeout(r, delay);
-            });
-            return label;
+        // Barrier-style assertion: prove both validators have *started* before
+        // either is allowed to finish. If the runtime were sequential the
+        // second `started` resolution would block on the first validator's
+        // completion, which can't happen until the test releases it.
+        let releaseAll: (() => void) | undefined;
+        const release = new Promise<void>((resolve) => {
+            releaseAll = resolve;
+        });
+        const startedSignals: Promise<void>[] = [];
+        const startedResolvers: Array<() => void> = [];
+
+        const barrier = (label: string): Validator => {
+            const idx = startedSignals.length;
+            startedSignals.push(new Promise<void>((resolve) => {
+                startedResolvers[idx] = resolve;
+            }));
+            return async () => {
+                startedResolvers[idx]?.();
+                await release;
+                return label;
+            };
         };
 
         const container = new Container<{ a: string, b: string }>();
-        container.mount('a', slow(30, 'A'));
-        container.mount('b', slow(30, 'B'));
+        container.mount('a', barrier('A'));
+        container.mount('b', barrier('B'));
 
-        const start = Date.now();
-        const out = await container.run({ a: 1, b: 1 }, { parallel: true });
-        const elapsed = Date.now() - start;
+        const runPromise = container.run({ a: 1, b: 1 }, { parallel: true });
 
+        // If `parallel: true` is honored, both validators start before either
+        // is released — `Promise.all(startedSignals)` resolves immediately.
+        // In sequential mode this `await` would deadlock (the second
+        // validator hasn't been called yet), so we cap with a short timeout
+        // that clearly distinguishes the two.
+        await Promise.race([
+            Promise.all(startedSignals),
+            new Promise<void>((_, reject) => {
+                setTimeout(() => reject(new Error('timeout: validators did not start in parallel')), 200);
+            }),
+        ]);
+
+        releaseAll?.();
+        const out = await runPromise;
         expect(out.a).toEqual('A');
         expect(out.b).toEqual('B');
-        // Allow generous slack for slow CI; sequential would be >= 60ms.
-        expect(elapsed).toBeLessThan(55);
     });
 
     it('should aggregate failures from all parallel validators', async () => {

--- a/packages/validup/test/unit/paths-to-include.spec.ts
+++ b/packages/validup/test/unit/paths-to-include.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { Container } from '../../src';
 import { stringValidator } from '../data';
 

--- a/packages/validup/test/unit/run-sync.spec.ts
+++ b/packages/validup/test/unit/run-sync.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Validator } from '../../src';
+import { Container, ValidupError } from '../../src';
+
+const isString: Validator = (ctx) => {
+    if (typeof ctx.value !== 'string') {
+        throw new Error('Value is not a string');
+    }
+    return ctx.value;
+};
+
+const isNumber: Validator = (ctx) => {
+    if (typeof ctx.value !== 'number') {
+        throw new Error('Value is not a number');
+    }
+    return ctx.value;
+};
+
+describe('Container.runSync', () => {
+    it('should validate synchronously when every mount is sync', () => {
+        const container = new Container<{ name: string, age: number }>();
+        container.mount('name', isString);
+        container.mount('age', isNumber);
+
+        const out = container.runSync({ name: 'Peter', age: 30 });
+
+        expect(out.name).toEqual('Peter');
+        expect(out.age).toEqual(30);
+    });
+
+    it('should throw when a validator returns a Promise', () => {
+        const container = new Container<{ name: string }>();
+        container.mount('name', async (ctx) => ctx.value);
+
+        expect(() => container.runSync({ name: 'Peter' })).toThrow(/returned a Promise/);
+    });
+
+    it('should aggregate sync validator failures into a ValidupError', () => {
+        const container = new Container<{ name: string, age: number }>();
+        container.mount('name', isString);
+        container.mount('age', isNumber);
+
+        try {
+            container.runSync({ name: 42, age: 'thirty' });
+            expect.fail('expected runSync to throw');
+        } catch (e) {
+            expect(e).toBeInstanceOf(ValidupError);
+            if (e instanceof ValidupError) {
+                expect(e.issues).toHaveLength(2);
+            }
+        }
+    });
+
+    it('should descend into nested containers that implement runSync', () => {
+        const inner = new Container<{ city: string }>();
+        inner.mount('city', isString);
+
+        const outer = new Container<{ address: { city: string } }>();
+        outer.mount('address', inner);
+
+        const out = outer.runSync({ address: { city: 'Berlin' } });
+        expect(out.address?.city).toEqual('Berlin');
+    });
+
+    it('should throw when a nested container does not implement runSync', () => {
+        const child: any = {
+            run: async (input: any) => input,
+            safeRun: async () => ({ success: true, data: {} }),
+        };
+
+        const parent = new Container<{ nested: Record<string, unknown> }>();
+        parent.mount('nested', child);
+
+        expect(() => parent.runSync({ nested: { a: 1 } })).toThrow(/does not implement runSync/);
+    });
+
+    it('should respect group filtering', () => {
+        const container = new Container<{ name: string, code: string }>();
+        container.mount('name', { group: 'create' }, isString);
+        container.mount('code', { group: 'update' }, isString);
+
+        const out = container.runSync({ name: 'Peter', code: 42 } as any, { group: 'create' });
+        expect(out.name).toEqual('Peter');
+        expect(out.code).toBeUndefined();
+    });
+
+    it('should fill defaults', () => {
+        const container = new Container<{ role: string }>();
+        const out = container.runSync({}, { defaults: { role: 'user' } });
+        expect(out.role).toEqual('user');
+    });
+
+    it('should expose runSync on safeRunSync as a Result wrapper', () => {
+        const container = new Container<{ name: string }>();
+        container.mount('name', isString);
+
+        const ok = container.safeRunSync({ name: 'Peter' });
+        expect(ok.success).toBe(true);
+        if (ok.success) {
+            expect(ok.data.name).toEqual('Peter');
+        }
+
+        const fail = container.safeRunSync({ name: 42 } as any);
+        expect(fail.success).toBe(false);
+    });
+});

--- a/packages/validup/test/vitest.config.ts
+++ b/packages/validup/test/vitest.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/validup/tsdown.config.ts
+++ b/packages/validup/tsdown.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -185,6 +185,8 @@ For expensive async validators (e.g. uniqueness checks against an HTTP endpoint)
 const $v = useValidup(uniqueUsernameValidator, form, { debounce: 300 });
 ```
 
+When a state change schedules a new run, the previous in-flight run is aborted via `AbortSignal` — async validators that pass `ctx.signal` to their I/O (e.g. `fetch(url, { signal: ctx.signal })`) cancel cleanly instead of completing wasted work. The composable also aborts pending runs when the owning effect scope tears down (component unmount). `$validate()` is intentionally **not** auto-cancellable, so a submit-time check can't be aborted by an intervening keystroke.
+
 ## Lazy Validation
 
 By default, `useValidup` runs validation **on mount** so `$invalid` reflects the initial state. For forms with expensive async validators (e.g. an HTTP-backed uniqueness check), this on-mount probe is wasteful. Pass `lazy: true` to skip it:
@@ -363,14 +365,15 @@ buildFormGroup({
 ### `useValidup(container, state, options?)`
 
 ```ts
-function useValidup<T extends ObjectLiteral>(
-    container: IContainer<T> | Ref<IContainer<T>>,
+function useValidup<T extends ObjectLiteral, C = unknown>(
+    container: IContainer<T, C> | Ref<IContainer<T, C>>,
     state: T | Ref<T>,
-    options?: ValidupComposableOptions<T>,
+    options?: ValidupComposableOptions<T, C>,
 ): ValidupComposable<T>;
 
-interface ValidupComposableOptions<T> {
+interface ValidupComposableOptions<T, C = unknown> {
     group?: MaybeRef<string | undefined>;
+    context?: MaybeRef<C | undefined>; // forwarded as ValidatorContext.context; reactive
     debounce?: number;
     name?: string;
     stopPropagation?: boolean;  // skip inject(), still provide() — aggregation root

--- a/packages/vue/src/module.ts
+++ b/packages/vue/src/module.ts
@@ -22,7 +22,6 @@ import {
 import type { Ref } from 'vue';
 import type {
     Issue,
-    IssueGroup,
     IssueItem,
     ObjectLiteral,
     Result,
@@ -30,8 +29,9 @@ import type {
 import {
     IssueCode,
     ValidupError,
+    flattenIssueGroups,
+    flattenIssueItems,
     isIssueGroup,
-    isIssueItem,
     isValidupError,
 } from 'validup';
 import { PARENT_INJECTION_KEY } from './helpers/child';
@@ -101,39 +101,17 @@ function isPrefixDirty(dirtyPaths: ReadonlySet<string>, key: string): boolean {
     return false;
 }
 
-function flattenIssueItems(issues: Issue[]): IssueItem[] {
-    const output: IssueItem[] = [];
-    for (const issue of issues) {
-        if (isIssueItem(issue)) {
-            output.push(issue);
-        } else {
-            output.push(...flattenIssueItems(issue.issues));
-        }
-    }
-    return output;
-}
-
-function flattenIssueGroups(issues: Issue[]): IssueGroup[] {
-    const output: IssueGroup[] = [];
-    for (const issue of issues) {
-        if (isIssueGroup(issue)) {
-            output.push(issue);
-            output.push(...flattenIssueGroups(issue.issues));
-        }
-    }
-    return output;
-}
-
-export function useValidup<T extends ObjectLiteral = ObjectLiteral>(
-    container: ContainerInput<T>,
+export function useValidup<T extends ObjectLiteral = ObjectLiteral, C = unknown>(
+    container: ContainerInput<T, C>,
     state: StateInput<T>,
-    options: ValidupComposableOptions<T> = {},
+    options: ValidupComposableOptions<T, C> = {},
 ): ValidupComposable<T> {
     const containerRef = (isRef(container) ? container : ref(container)) as Ref<any>;
     const stateRef = (isRef(state) ? state : ref(state)) as Ref<T>;
     // Normalize MaybeRef explicitly — `toRef(maybeRef)` semantics shifted across
     // Vue 3.x minor versions; `isRef` keeps reactivity intact regardless.
     const groupRef = (isRef(options.group) ? options.group : ref(options.group)) as Ref<string | undefined>;
+    const contextRef = (isRef(options.context) ? options.context : ref(options.context)) as Ref<C | undefined>;
 
     const dirtyPaths = reactive<Set<string>>(new Set());
     const internalIssues = ref<Issue[]>([]);
@@ -142,20 +120,34 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral>(
 
     let runId = 0;
     let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    // Auto-cancellation for scheduled (state-driven) runs only — `$validate()`
+    // is intentionally non-cancellable so a submit-time check doesn't get
+    // stomped by a concurrent state change.
+    let scheduleAbortController: AbortController | undefined;
 
-    async function runOnce(): Promise<Result<T>> {
+    async function runOnce(signal?: AbortSignal): Promise<Result<T>> {
         const id = ++runId;
         pending.value = true;
         try {
             const c = unref(containerRef);
             let result: Result<T>;
             try {
-                result = await c.safeRun(unref(stateRef) as Record<string, any>, { group: groupRef.value });
+                result = await c.safeRun(
+                    unref(stateRef) as Record<string, any>,
+                    {
+                        group: groupRef.value, 
+                        context: contextRef.value, 
+                        signal, 
+                    },
+                );
             } catch (rawError) {
-                // Defensive: `safeRun` is contractually never supposed to throw,
-                // but a buggy or wrapped `IContainer` implementation might.
-                // Surface the throw as a synthetic `Result` failure so the
-                // composable stays consistent (`$invalid`/`$errors` reflect it).
+                // `safeRun` rethrows when `signal.aborted` — a fresher schedule
+                // is taking over, so silently drop this run's outcome. Any
+                // other throw is defensive (a buggy IContainer that breaks
+                // safeRun's contract): surface it as a synthetic failure.
+                if (signal?.aborted) {
+                    return { success: false, error: new ValidupError() } as Result<T>;
+                }
                 const error = isValidupError(rawError) ?
                     rawError :
                     new ValidupError([{
@@ -179,20 +171,23 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral>(
     }
 
     function schedule() {
+        scheduleAbortController?.abort();
+        scheduleAbortController = new AbortController();
+        const { signal } = scheduleAbortController;
         if (options.debounce && options.debounce > 0) {
             if (debounceTimer) {
                 clearTimeout(debounceTimer);
             }
             debounceTimer = setTimeout(() => {
-                void runOnce();
+                void runOnce(signal);
             }, options.debounce);
             return;
         }
-        void runOnce();
+        void runOnce(signal);
     }
 
     watch(
-        [containerRef, groupRef, stateRef],
+        [containerRef, groupRef, stateRef, contextRef],
         () => {
             schedule();
         },
@@ -481,17 +476,22 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral>(
     }
 
     async function $validate(): Promise<Result<T>> {
-        // Cancel any pending debounced run — `$validate` is the explicit
-        // submit-time check and must not race with a stale debounced result.
+        // Cancel any pending debounced run AND abort any in-flight scheduled
+        // run — `$validate` is the explicit submit-time check and must not
+        // race with a stale debounced result.
         if (debounceTimer) {
             clearTimeout(debounceTimer);
             debounceTimer = undefined;
         }
+        scheduleAbortController?.abort();
+        scheduleAbortController = undefined;
         // Eagerly mark every known state key dirty so the upcoming run's
         // results surface immediately. Issue paths from validation targets
         // outside the state object (e.g. `address.city` against `state = {}`)
         // are caught after the run completes via `markIssuePathsDirty()`.
         markStateKeysDirty();
+        // No signal — `$validate` is intentionally non-cancellable so an
+        // intervening state-change-driven schedule can't abort the submit.
         const result = await runOnce();
         markIssuePathsDirty();
         return result;
@@ -550,6 +550,16 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral>(
         if (getCurrentScope()) {
             onScopeDispose(() => parent!.unregister(options.name as string));
         }
+    }
+
+    if (inComponent && getCurrentScope()) {
+        // Abort in-flight scheduled runs when the owning effect scope tears
+        // down (component unmount, manual scope dispose). $validate runs are
+        // not aborted because they don't carry a signal.
+        onScopeDispose(() => {
+            scheduleAbortController?.abort();
+            scheduleAbortController = undefined;
+        });
     }
 
     return composable;

--- a/packages/vue/src/module.ts
+++ b/packages/vue/src/module.ts
@@ -552,11 +552,17 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral, C = unknown>
         }
     }
 
-    if (inComponent && getCurrentScope()) {
-        // Abort in-flight scheduled runs when the owning effect scope tears
-        // down (component unmount, manual scope dispose). $validate runs are
-        // not aborted because they don't carry a signal.
+    if (getCurrentScope()) {
+        // Abort in-flight scheduled runs AND drop any pending debounced
+        // schedule when the owning effect scope tears down (component unmount,
+        // manual `scope.stop()`, etc.). Without clearing the timer a queued
+        // `runOnce()` could still fire after teardown.
+        // `$validate` runs are not aborted because they don't carry a signal.
         onScopeDispose(() => {
+            if (debounceTimer) {
+                clearTimeout(debounceTimer);
+                debounceTimer = undefined;
+            }
             scheduleAbortController?.abort();
             scheduleAbortController = undefined;
         });

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -82,9 +82,18 @@ export interface ValidupComposable<T extends ObjectLiteral = ObjectLiteral> {
     readonly fields: { readonly [K in keyof T]: FieldState<T[K]> } & Record<string, FieldState<any>>;
 }
 
-export interface ValidupComposableOptions<T extends ObjectLiteral> {
+export interface ValidupComposableOptions<T extends ObjectLiteral, C = unknown> {
     /** Active container group. Reactive when a ref is passed. */
     group?: MaybeRef<string | undefined>;
+
+    /**
+     * Caller-supplied context surfaced on every `ValidatorContext.context` for
+     * this run. Reactive — when wrapped in a `ref`, changes trigger re-validation
+     * the same way `state`/`group` do. Useful for request-scoped data (current
+     * user, locale, feature flags) that validators need but isn't part of the
+     * validated state.
+     */
+    context?: MaybeRef<C | undefined>;
 
     /** Debounce window in ms for re-running validation on state change. Default: 0. */
     debounce?: number;
@@ -143,4 +152,4 @@ export interface ParentRegistry {
 }
 
 export type StateInput<T extends ObjectLiteral> = T | Ref<T>;
-export type ContainerInput<T extends ObjectLiteral> = IContainer<T> | Ref<IContainer<T>>;
+export type ContainerInput<T extends ObjectLiteral, C = unknown> = IContainer<T, C> | Ref<IContainer<T, C>>;

--- a/packages/vue/test/unit/abort-signal.spec.ts
+++ b/packages/vue/test/unit/abort-signal.spec.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { nextTick, reactive } from 'vue';
+import { Container } from 'validup';
+import type { Validator } from 'validup';
+import { useValidup } from '../../src';
+
+async function flush() {
+    await nextTick();
+    await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+    });
+    await nextTick();
+}
+
+describe('useValidup abort behaviour', () => {
+    it('aborts the previous scheduled run when state changes mid-flight', async () => {
+        const seen: { value: unknown; aborted: boolean }[] = [];
+
+        const slow: Validator = async (ctx) => {
+            // Honor the signal so the abort short-circuits the await.
+            await new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(resolve, 30);
+                ctx.signal?.addEventListener('abort', () => {
+                    clearTimeout(timer);
+                    reject(ctx.signal!.reason);
+                });
+            });
+            seen.push({ value: ctx.value, aborted: ctx.signal?.aborted ?? false });
+            return ctx.value;
+        };
+
+        const container = new Container<{ name: string }>();
+        container.mount('name', slow);
+
+        const state = reactive({ name: 'a' });
+        useValidup(container, state);
+
+        // Initial run starts. Mutate before it can complete.
+        await nextTick();
+        state.name = 'ab';
+        await nextTick();
+        state.name = 'abc';
+
+        await flush();
+        await new Promise<void>((resolve) => {
+            setTimeout(resolve, 50);
+        });
+
+        // Only the latest scheduled run should reach completion; earlier ones
+        // are aborted before pushing into `seen`.
+        const completed = seen.filter((s) => !s.aborted);
+        expect(completed.length).toBeLessThanOrEqual(1);
+        if (completed.length === 1) {
+            expect(completed[0]?.value).toEqual('abc');
+        }
+    });
+
+    it('runs $validate without an abort signal', async () => {
+        const seen: (AbortSignal | undefined)[] = [];
+
+        const validator: Validator = (ctx) => {
+            seen.push(ctx.signal);
+            return ctx.value;
+        };
+
+        const container = new Container<{ name: string }>();
+        container.mount('name', validator);
+
+        const state = reactive({ name: 'a' });
+        const $v = useValidup(container, state, { lazy: true });
+
+        const result = await $v.$validate();
+
+        expect(result.success).toBe(true);
+        expect(seen).toHaveLength(1);
+        // The submit-time run carries no signal — so an intervening
+        // state-change-driven schedule cannot abort it.
+        expect(seen[0]).toBeUndefined();
+    });
+});

--- a/packages/vue/test/unit/abort-signal.spec.ts
+++ b/packages/vue/test/unit/abort-signal.spec.ts
@@ -53,13 +53,13 @@ describe('useValidup abort behaviour', () => {
             setTimeout(resolve, 50);
         });
 
-        // Only the latest scheduled run should reach completion; earlier ones
-        // are aborted before pushing into `seen`.
+        // Exactly one run — the final 'abc' — must complete within the
+        // 50 ms wait; earlier ones are aborted before pushing into `seen`.
+        // `toBe(1)` (vs. `toBeLessThanOrEqual(1)`) prevents a regression
+        // where the final run also gets aborted from silently passing.
         const completed = seen.filter((s) => !s.aborted);
-        expect(completed.length).toBeLessThanOrEqual(1);
-        if (completed.length === 1) {
-            expect(completed[0]?.value).toEqual('abc');
-        }
+        expect(completed.length).toBe(1);
+        expect(completed[0]?.value).toEqual('abc');
     });
 
     it('runs $validate without an abort signal', async () => {

--- a/packages/vue/test/vitest.config.ts
+++ b/packages/vue/test/vitest.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/vue/tsdown.config.ts
+++ b/packages/vue/tsdown.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -10,6 +10,10 @@ A [validup](https://www.npmjs.com/package/validup) integration for [zod](https:/
 
 Wrap any zod schema as a validup `Validator`, mount it on a `Container` path, and let validup orchestrate path expansion, group filtering, and error aggregation while zod does the actual schema parsing.
 
+> ℹ️ **Already on zod 3.24+ and don't need vendor-specific fields?**
+>
+> [`@validup/standard-schema`](https://npmjs.com/package/@validup/standard-schema) covers zod via the [Standard Schema](https://standardschema.dev) protocol and works the same against valibot, arktype, and effect-schema. Pick `@validup/zod` when you specifically need `expected`/`received` on issues or the bidirectional `validup ↔ zod` mapping.
+
 > 🚧 **Work in Progress**
 >
 > Validup is currently under active development and is not yet ready for production.
@@ -90,8 +94,10 @@ container.mount('password', { group: 'update' }, passwordValidator);
 The factory receives the full `ValidatorContext`:
 
 ```typescript
-type ZodCreateFn = (ctx: ValidatorContext) => ZodType;
+type ZodCreateFn<C = unknown> = (ctx: ValidatorContext<C>) => ZodType;
 ```
+
+`createValidator<C>(...)` is generic over the validup context type, so factories can read typed `ctx.context` when the parent container declares one (`Container<T, C>`).
 
 ## Error Mapping
 
@@ -150,7 +156,7 @@ try {
 | `ZodIssue`                   | Re-exported alias for `$ZodRawIssue` from `zod/v4/core`.                     |
 
 ```typescript
-function createValidator(input: ZodType | ((ctx: ValidatorContext) => ZodType)): Validator;
+function createValidator<C = unknown>(input: ZodType | ((ctx: ValidatorContext<C>) => ZodType)): Validator<C>;
 ```
 
 ## License

--- a/packages/zod/src/module.ts
+++ b/packages/zod/src/module.ts
@@ -10,9 +10,9 @@ import { ValidupError } from 'validup';
 import type { ZodType } from 'zod';
 import { buildIssuesForZodError } from './error';
 
-type ZodCreateFn = (ctx: ValidatorContext) => ZodType;
+type ZodCreateFn<C = unknown> = (ctx: ValidatorContext<C>) => ZodType;
 
-export function createValidator(input: ZodCreateFn | ZodType) : Validator {
+export function createValidator<C = unknown>(input: ZodCreateFn<C> | ZodType) : Validator<C> {
     return async (ctx): Promise<unknown> => {
         let zod : ZodType;
         if (typeof input === 'function') {

--- a/packages/zod/test/unit/error.spec.ts
+++ b/packages/zod/test/unit/error.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import {
     Container, 
     ValidupError, 

--- a/packages/zod/test/unit/module.spec.ts
+++ b/packages/zod/test/unit/module.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
     Container,

--- a/packages/zod/test/vitest.config.ts
+++ b/packages/zod/test/vitest.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/packages/zod/tsdown.config.ts
+++ b/packages/zod/tsdown.config.ts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
         "packages/routup": {"component": "routup"},
         "packages/express-validator": {"component": "express-validator"},
         "packages/vue": {"component": "vue"},
-        "packages/zod": {"component": "zod"}
+        "packages/zod": {"component": "zod"},
+        "packages/standard-schema": {"component": "standard-schema"}
     },
     "plugins": [
         {


### PR DESCRIPTION
Lands the design-scale items from .agents/plans/improvements.md plus quick follow-ups and a new integration package.

Core (validup):
- Item 4: AbortSignal threaded through ContainerRunOptions and ValidatorContext; run() throws between mounts, safeRun rethrows abort, signal forwarded to nested run() and validator ctx.signal
- Item 5: user-supplied context propagated via Container<T, C>, Validator<C>, ValidatorContext<C>, ContainerRunOptions<T, C> (defaults preserve compat)
- Item 6: opt-in ContainerRunOptions.parallel runs mounts concurrently via Promise.allSettled; results merged in registration order; nested forwarding
- Item 7: runSync / safeRunSync sync fast path; throws RunSyncViolationError (duck-typed isRunSyncViolation) on Promise return or missing nested runSync
- Item 9: IssueCode is now a const + IssueCodeRegistry interface for typed declaration-merging extension; IssueItem.code widened to allow ad-hoc strings
- Item 10: IssueBase.params for lazy re-rendering; formatIssue(issue, templates?, fallback?) with @ebec/core's interpolate; runtime populates { name } on wrapping IssueGroup
- Item 12: MountOptions.optional accepts a predicate alongside boolean
- Item 13: isError uses instanceof Error as primary check, tightened duck-type fallback to require name + message
- ebec adoption: ValidupError extends @ebec/core BaseError (code, cause, toJSON overridden to include issues)
- Quick follow-ups: defaults forwarded into nested containers via resolveDefaults; flattenIssueItems / flattenIssueGroups hoisted from @validup/vue into the core barrel; literal-dot mount-key limitation documented on BaseMount.path and Container.mergePaths
- Refactor: resolvePathFilter / resolveDefaults extracted into helpers/; recordMountError / finalizeOutput / wrapSafeRunError / resolveContainerFilters factored as private helpers shared by run() / runSync() / runParallel()

Integrations:
- New @validup/standard-schema package: createValidator<C>(schema | factory) for any Standard Schema vendor (zod 3.24+, valibot, arktype, …); registered in release-please-config and the manifest at 0.1.0
- @validup/zod / @validup/express-validator: createValidator<C> generic over the validup context type
- @validup/routup: RoutupContainerAdapter<T, C> + RoutupContainerRunOptions<T, C>
- @validup/vue: useValidup<T, C> + reactive options.context; internal AbortController per scheduled run (auto-aborts the previous); $validate intentionally non-cancellable so submit-time runs aren't stomped by intervening keystrokes; flatten helpers re-imported from validup core

Tests:
- Explicit { describe, expect, it } imports retrofitted across all spec files instead of relying on globals: true
- New specs: abort-signal, context, parallel, run-sync, format, standard-schema/module, vue/abort-signal
- 170 specs total (28 new), all passing

Docs:
- Validup README gains Cancellation, Parallel Execution, Sync Fast Path, Localized Messages, Context sections; API reference table updated
- New @validup/standard-schema README with chooser table vs @validup/zod
- Root README, AGENTS.md, .agents/structure.md, .agents/testing.md updated for the new package count and ebec dependency
- Per-integration READMEs updated (Routup, Vue, Zod, express-validator)

Verified: 6 builds, 6 test projects, lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New @validup/standard-schema integration for Standard Schema validators.
  * Typed caller context for validators (generic ValidatorContext<C>).
  * AbortSignal cancellation for in-flight validations.
  * Parallel execution option for runs.
  * Synchronous run variants (runSync / safeRunSync).
  * Issue formatting utility and issue-flattening helpers.

* **Improvements**
  * Structured errors: ValidupError now exposes richer error metadata.
  * Extensible issue-code registry for third-party codes.

* **Documentation**
  * Updated READMEs and guides to reflect these APIs and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->