### PR TITLE
feat: compile-time output typing (improvements plan item 11)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1,5 +1,17 @@
 # Conventions
 
+## Documentation surfaces
+
+Three audiences read documentation in this repo. After any code, tooling, or API change, update every surface that mentions the changed thing — in the **same pass** as the code change, not as a follow-up.
+
+| Surface                                        | Audience                | Update when …                                                                                                |
+|------------------------------------------------|-------------------------|--------------------------------------------------------------------------------------------------------------|
+| Root `README.md` + each `packages/*/README.md` | npm / GitHub readers    | Public API, exports, install, scripts, supported Node versions, integration list, dependency layers change.  |
+| VitePress site under `docs/src/**`             | End users on the docs site | New / removed concepts, options, run modes, integrations; user-facing examples; signatures; cross-links.  |
+| `AGENTS.md` + `.agents/{structure,architecture,testing,conventions}.md` (this file) | Future agents & human contributors | Repo layout, package roles, runtime behavior, testing setup, lint/format rules, release/CI mechanics change. |
+
+When adding a new VitePress page, slot it into the sidebar in `docs/src/.vitepress/config.mts` and cross-link it from neighboring pages (the guide overview's "where to next" list, related-page `::: tip` blocks). When adding a new package or moving a module between packages, update `.agents/structure.md` and `.agents/architecture.md` so the dependency-layer diagram and per-package tables stay accurate. Stale docs are treated as a defect, not a separate task — verify all three surfaces before reporting the change as done.
+
 ## TypeScript
 
 - Each package has a single `tsconfig.json` extending the root. The root extends `@tada5hi/tsconfig` and overrides:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ try {
 | 🚦 **Group-aware**       | Run different validations for `create` / `update` / custom groups from the same container.   |
 | ❓ **Optional handling** | Per-mount control over `undefined` / `null` / falsy semantics.                                 |
 | 📋 **Structured errors** | Discriminated `Issue` items and groups with code, path, message, expected, received.          |
-| 🛡️ **Type-safe**         | `Container<T>` propagates the output shape; mount paths are checked against `T`.              |
+| 🛡️ **Type-safe**         | `Container<T>` propagates the output shape; mount paths are checked against `T`. The opt-in `defineSchema()` builder accumulates `T` from the registered mounts so `run()`'s static return type matches what was registered. |
 
 ## Repository Layout
 

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -67,6 +67,7 @@ export default defineConfig({
                     items: [
                         { text: 'Overview', link: '/guide/' },
                         { text: 'Container', link: '/guide/container' },
+                        { text: 'Builder API', link: '/guide/builder' },
                         { text: 'Validator', link: '/guide/validator' },
                         { text: 'Issues & Errors', link: '/guide/issues' },
                     ],

--- a/docs/src/guide/builder.md
+++ b/docs/src/guide/builder.md
@@ -18,56 +18,66 @@ import { createValidator } from '@validup/zod';
 import { z } from 'zod';
 
 const schema = defineSchema()
-    .field('foo', createValidator(z.string()))   // accumulated: { foo: string }
-    .field('age', createValidator(z.number()))   // accumulated: { foo: string; age: number }
+    .mount('foo', createValidator(z.string()))                            // { foo: string }
+    .mount('age', { optional: true }, createValidator(z.number().int()))  // { foo: string; age?: number }
     .build();
 
 const out = await schema.run(input);
-// out: { foo: string; age: number } — inferred, not declared
+// out: { foo: string; age?: number } — inferred, not declared
 ```
 
-`schema` is a regular `Container<{ foo: string; age: number }, unknown>`. `.build()` materializes the container; everything `Container` exposes (`run`, `safeRun`, `runSync`, `runParallel`, `safeRunSync`) is available.
+`schema` is a regular `Container<{ foo: string; age?: number }, unknown>`. `.build()` materializes the container; everything `Container` exposes (`run`, `safeRun`, `runSync`, `runParallel`, `safeRunSync`) is available.
 
-## Methods
+## `mount(...)`
+
+The builder mirrors `Container.mount`'s keyed forms — `(key, target)` and `(key, options, target)` — and dispatches on the target type:
+
+| Target type                                 | Effect on `T`                                                                       |
+|---------------------------------------------|-------------------------------------------------------------------------------------|
+| `Validator<C, Out>`                         | adds `{ [K]: Awaited<Out> }`                                                        |
+| `Validator<C, Out>` with `options.optional` | adds `{ [K]?: Awaited<Out> }`                                                       |
+| `Builder<U, C>`                             | adds `{ [K]: U }` and auto-`.build()`s the child                                    |
+| `IContainer<U, C>` (e.g. `Container<U, C>`) | adds `{ [K]: U }`                                                                   |
+
+```typescript
+defineSchema()
+    .mount('id', isString)                                       // T & { id: string }
+    .mount('email', { optional: true }, isString)                // T & { email?: string }
+    .mount('address', defineSchema().mount('city', isString))    // T & { address: { city: string } }
+    .build();
+```
+
+The same builder also exposes container-level switches that don't add fields:
 
 ```typescript
 interface Builder<T extends Record<string, any>, C = unknown> {
-    field<K extends string, Out>(
+    mount<K extends string, V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>>(
         key: K,
-        validator: Validator<C, Out>,
-        options?: MountOptions,
-    ): Builder<T & { [P in K]: Awaited<Out> }, C>;
+        target: V,
+    ): Builder<T & Mounted<K, V, undefined>, C>;
 
-    optional<K extends string, Out>(
+    mount<
+        K extends string,
+        const O extends MountOptions,
+        V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>,
+    >(
         key: K,
-        validator: Validator<C, Out>,
-        options?: Omit<MountOptions, 'optional'>,
-    ): Builder<T & { [P in K]?: Awaited<Out> }, C>;
-
-    nest<K extends string, U>(
-        key: K,
-        child: Builder<U, C> | IContainer<U, C>,
-        options?: MountOptions,
-    ): Builder<T & { [P in K]: U }, C>;
+        options: O,
+        target: V,
+    ): Builder<T & Mounted<K, V, O>, C>;
 
     oneOf(): Builder<T, C>;
     pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
     pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
-
     build(): Container<T, C>;
 }
 ```
 
-| Method                                                | Effect on `T`                                  | Notes                                                                                       |
-|-------------------------------------------------------|------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `.field(key, validator, options?)`                    | adds `{ [K]: Awaited<Out> }`                   | Required field. `Out` is inferred from the validator's return type.                         |
-| `.optional(key, validator, options?)`                 | adds `{ [K]?: Awaited<Out> }`                  | Sets `optional: true`. `optionalValue` / `optionalInclude` can still be passed via options. |
-| `.nest(key, builder \| container, options?)`          | adds `{ [K]: U }`                              | If a `Builder` is given, it is `.build()`-ed automatically.                                 |
-| `.oneOf()`                                            | unchanged                                      | Container-level `oneOf` flag. See [One-Of](/guide/one-of).                                  |
-| `.pathsToInclude(...keys)` / `.pathsToExclude(...keys)` | unchanged                                    | Restrict execution to / from specific top-level keys.                                       |
-| `.build()`                                            | —                                              | Returns a `Container<T, C>`.                                                                |
-
 Builders are **immutable** — every method returns a new builder, so chains may fork without leaking state.
+
+::: tip Optional widening
+The `?`-widening only fires when TypeScript sees `optional` as the literal `true` (or a predicate function). The `const` modifier on the second overload preserves literal types from inline option objects, so `.mount('email', { optional: true }, isString)` just works. A pre-typed `MountOptions` variable whose `optional` is `boolean` keeps the field required.
+:::
 
 ## Inferring `Out`
 
@@ -87,7 +97,7 @@ const slug: Validator<unknown, string> = (ctx) => {
 };
 
 const schema = defineSchema()
-    .field('slug', slug)   // accumulated: { slug: string }
+    .mount('slug', slug)   // accumulated: { slug: string }
     .build();
 ```
 
@@ -95,7 +105,7 @@ const schema = defineSchema()
 
 ```typescript
 const schema = defineSchema()
-    .field('count', (ctx) => {
+    .mount('count', (ctx) => {
         const n = Number(ctx.value);
         if (!Number.isInteger(n)) throw new Error('not an int');
         return n;        // Out inferred as number
@@ -113,13 +123,13 @@ Pass the context type as the generic parameter to flow it through nested builder
 type AppContext = { userId: string };
 
 const schema = defineSchema<AppContext>()
-    .field('slug', async (ctx) => {
+    .mount('slug', async (ctx) => {
         // ctx.context is typed as AppContext
         await assertSlugAvailable(ctx.value, ctx.context.userId);
         return ctx.value;
     })
-    .nest('inner', defineSchema<AppContext>()
-        .field('whoami', (ctx) => ctx.context.userId))
+    .mount('inner', defineSchema<AppContext>()
+        .mount('whoami', (ctx) => ctx.context.userId))
     .build();
 
 await schema.run(input, { context: { userId: 'u-42' } });
@@ -127,22 +137,22 @@ await schema.run(input, { context: { userId: 'u-42' } });
 
 ## Nesting
 
-`nest(key, child, options?)` accepts either a `Builder` (auto-`.build()`-ed) or an existing `Container`. The child's accumulated shape becomes `T[K]`:
+Pass either a `Builder` (auto-`.build()`-ed) or an existing `Container` as the mount target. The child's accumulated shape becomes `T[K]`:
 
 ```typescript
 const address = defineSchema()
-    .field('city', isString)
-    .field('country', isString);
+    .mount('city', isString)
+    .mount('country', isString);
 
 const user = defineSchema()
-    .field('name', isString)
-    .nest('address', address)        // address auto-builds
+    .mount('name', isString)
+    .mount('address', address)        // address auto-builds
     .build();
 
 // user is Container<{ name: string; address: { city: string; country: string } }>
 ```
 
-For framework integrations (e.g. mounting a routup adapter) pass the underlying `Container` instance directly.
+For framework integrations (e.g. mounting a routup adapter) pass the underlying `Container` instance directly — same overload.
 
 ## When to use which API
 
@@ -157,5 +167,6 @@ The imperative `Container` API is **not** deprecated — it remains the runtime 
 ## Caveats
 
 - **`oneOf()` and `T`.** A `oneOf` container's `T` stays as the **intersection** of branches, but only one branch's keys actually appear at runtime. The intersection is honest about *possible* keys; wrap with your own discriminated union when that fits better.
-- **Cross-field refinements** don't fit the per-field model. Continue to mount them either as a top-level validator on a non-content key (`.field('_invariants', crossFieldValidator)`) or as a `oneOf` branch.
+- **Cross-field refinements** don't fit the per-field model. Continue to mount them either as a top-level validator on a non-content key (`.mount('_invariants', crossFieldValidator)`) or as a `oneOf` branch.
 - **Group exhaustiveness.** The builder guarantees every key in `T` was registered at *build time*. It does not guarantee that, e.g., `group: 'create'` covers every required field for that group — the runtime still skips group-mismatched mounts.
+- **Same-key remount.** Calling `.mount('name', ...)` twice with different groups (a pattern from the README's `RoleValidator`) is not expressible in the builder — the second call overrides the first's `Out` via intersection. Use the imperative `Container` for that case.

--- a/docs/src/guide/builder.md
+++ b/docs/src/guide/builder.md
@@ -36,7 +36,7 @@ The builder mirrors `Container.mount`'s keyed forms — `(key, target)` and `(ke
 |---------------------------------------------|-------------------------------------------------------------------------------------|
 | `Validator<C, Out>`                         | adds `{ [K]: Awaited<Out> }`                                                        |
 | `Validator<C, Out>` with `options.optional` | adds `{ [K]?: Awaited<Out> }`                                                       |
-| `Builder<U, C>`                             | adds `{ [K]: U }` and auto-`.build()`s the child                                    |
+| `IBuilder<U, C>`                            | adds `{ [K]: U }` and auto-`.build()`s the child                                    |
 | `IContainer<U, C>` (e.g. `Container<U, C>`) | adds `{ [K]: U }`                                                                   |
 
 ```typescript
@@ -50,25 +50,25 @@ defineSchema()
 The same builder also exposes container-level switches that don't add fields:
 
 ```typescript
-interface Builder<T extends Record<string, any>, C = unknown> {
-    mount<K extends string, V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>>(
+interface IBuilder<T extends Record<string, any>, C = unknown> {
+    mount<K extends string, V extends Validator<C, any> | IBuilder<any, C> | IContainer<any, C>>(
         key: K,
         target: V,
-    ): Builder<T & Mounted<K, V, undefined>, C>;
+    ): IBuilder<T & Mounted<K, V, undefined>, C>;
 
     mount<
         K extends string,
         const O extends MountOptions,
-        V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>,
+        V extends Validator<C, any> | IBuilder<any, C> | IContainer<any, C>,
     >(
         key: K,
         options: O,
         target: V,
-    ): Builder<T & Mounted<K, V, O>, C>;
+    ): IBuilder<T & Mounted<K, V, O>, C>;
 
-    oneOf(): Builder<T, C>;
-    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
-    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
+    oneOf(): IBuilder<T, C>;
+    pathsToInclude(...paths: (keyof T & string)[]): IBuilder<T, C>;
+    pathsToExclude(...paths: (keyof T & string)[]): IBuilder<T, C>;
     build(): Container<T, C>;
 }
 ```

--- a/docs/src/guide/builder.md
+++ b/docs/src/guide/builder.md
@@ -167,6 +167,20 @@ The imperative `Container` API is **not** deprecated — it remains the runtime 
 ## Caveats
 
 - **`oneOf()` and `T`.** A `oneOf` container's `T` stays as the **intersection** of branches, but only one branch's keys actually appear at runtime. The intersection is honest about *possible* keys; wrap with your own discriminated union when that fits better.
-- **Cross-field refinements** don't fit the per-field model. Continue to mount them either as a top-level validator on a non-content key (`.mount('_invariants', crossFieldValidator)`) or as a `oneOf` branch.
+- **Cross-field refinements** don't fit the per-field model. Mount them as a top-level validator on a synthetic key — `ctx.data` exposes every sibling value:
+
+    ```typescript
+    const schema = defineSchema()
+        .mount('email', emailValidator)
+        .mount('confirmEmail', emailValidator)
+        .mount('_crossField', (ctx) => {
+            if (ctx.data.email !== ctx.data.confirmEmail) {
+                throw new Error('emails must match');
+            }
+        })
+        .build();
+    ```
+
+  Avoid using `.oneOf()` for this — that toggles the entire container to "succeed if any branch passes," which is the wrong semantic for "all invariants must hold."
 - **Group exhaustiveness.** The builder guarantees every key in `T` was registered at *build time*. It does not guarantee that, e.g., `group: 'create'` covers every required field for that group — the runtime still skips group-mismatched mounts.
-- **Same-key remount.** Calling `.mount('name', ...)` twice with different groups (a pattern from the README's `RoleValidator`) is not expressible in the builder — the second call overrides the first's `Out` via intersection. Use the imperative `Container` for that case.
+- **Same-key remount.** Calling `.mount('foo', ...)` twice with different validators (e.g. sanitize-then-validate) is supported: the type accumulator follows the runtime's "last write wins" behavior, so the second call's `Out` overrides the first's. The imperative `Container` is still preferable when the *same key* needs different mounts per group (the `RoleValidator` pattern from the validup README), since the builder can't express two same-key mounts with disjoint `MountOptions.group` filters.

--- a/docs/src/guide/builder.md
+++ b/docs/src/guide/builder.md
@@ -1,0 +1,161 @@
+# Builder API
+
+`new Container<T>()` happily accepts mounts that don't cover every required key of `T`, and `run()` returns `T` regardless. The TypeScript shape is a promise the runtime can't keep:
+
+```typescript
+const c = new Container<{ foo: string; bar: number }>();
+c.mount('foo', isString);          // ⚠️  bar is never validated
+const out = await c.run({});       // out: { foo, bar } — bar is undefined at runtime
+```
+
+`defineSchema()` is an opt-in, type-accumulating wrapper around `Container` that derives `T` *from the registered mounts* — so `run()`'s static return type reflects exactly what was registered.
+
+## Quick Start
+
+```typescript
+import { defineSchema } from 'validup';
+import { createValidator } from '@validup/zod';
+import { z } from 'zod';
+
+const schema = defineSchema()
+    .field('foo', createValidator(z.string()))   // accumulated: { foo: string }
+    .field('age', createValidator(z.number()))   // accumulated: { foo: string; age: number }
+    .build();
+
+const out = await schema.run(input);
+// out: { foo: string; age: number } — inferred, not declared
+```
+
+`schema` is a regular `Container<{ foo: string; age: number }, unknown>`. `.build()` materializes the container; everything `Container` exposes (`run`, `safeRun`, `runSync`, `runParallel`, `safeRunSync`) is available.
+
+## Methods
+
+```typescript
+interface Builder<T extends Record<string, any>, C = unknown> {
+    field<K extends string, Out>(
+        key: K,
+        validator: Validator<C, Out>,
+        options?: MountOptions,
+    ): Builder<T & { [P in K]: Awaited<Out> }, C>;
+
+    optional<K extends string, Out>(
+        key: K,
+        validator: Validator<C, Out>,
+        options?: Omit<MountOptions, 'optional'>,
+    ): Builder<T & { [P in K]?: Awaited<Out> }, C>;
+
+    nest<K extends string, U>(
+        key: K,
+        child: Builder<U, C> | IContainer<U, C>,
+        options?: MountOptions,
+    ): Builder<T & { [P in K]: U }, C>;
+
+    oneOf(): Builder<T, C>;
+    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
+    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
+
+    build(): Container<T, C>;
+}
+```
+
+| Method                                                | Effect on `T`                                  | Notes                                                                                       |
+|-------------------------------------------------------|------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `.field(key, validator, options?)`                    | adds `{ [K]: Awaited<Out> }`                   | Required field. `Out` is inferred from the validator's return type.                         |
+| `.optional(key, validator, options?)`                 | adds `{ [K]?: Awaited<Out> }`                  | Sets `optional: true`. `optionalValue` / `optionalInclude` can still be passed via options. |
+| `.nest(key, builder \| container, options?)`          | adds `{ [K]: U }`                              | If a `Builder` is given, it is `.build()`-ed automatically.                                 |
+| `.oneOf()`                                            | unchanged                                      | Container-level `oneOf` flag. See [One-Of](/guide/one-of).                                  |
+| `.pathsToInclude(...keys)` / `.pathsToExclude(...keys)` | unchanged                                    | Restrict execution to / from specific top-level keys.                                       |
+| `.build()`                                            | —                                              | Returns a `Container<T, C>`.                                                                |
+
+Builders are **immutable** — every method returns a new builder, so chains may fork without leaking state.
+
+## Inferring `Out`
+
+The integration packages' `createValidator(...)` functions infer the per-field `Out` from the underlying schema:
+
+- `@validup/zod` — `Out = z.output<Schema>`
+- `@validup/standard-schema` — `Out = StandardSchemaV1.InferOutput<Schema>`
+
+Hand-written validators participate too. Either annotate the return type:
+
+```typescript
+const slug: Validator<unknown, string> = (ctx) => {
+    if (typeof ctx.value !== 'string') {
+        throw new Error('not a string');
+    }
+    return ctx.value.toLowerCase();
+};
+
+const schema = defineSchema()
+    .field('slug', slug)   // accumulated: { slug: string }
+    .build();
+```
+
+…or write the function inline so TypeScript infers from the body:
+
+```typescript
+const schema = defineSchema()
+    .field('count', (ctx) => {
+        const n = Number(ctx.value);
+        if (!Number.isInteger(n)) throw new Error('not an int');
+        return n;        // Out inferred as number
+    })
+    .build();
+```
+
+A bare `Validator<C>` (without the second generic) contributes `unknown` — which matches today's `Container<T>` behavior, so existing code keeps compiling.
+
+## Context
+
+Pass the context type as the generic parameter to flow it through nested builders and validator factories:
+
+```typescript
+type AppContext = { userId: string };
+
+const schema = defineSchema<AppContext>()
+    .field('slug', async (ctx) => {
+        // ctx.context is typed as AppContext
+        await assertSlugAvailable(ctx.value, ctx.context.userId);
+        return ctx.value;
+    })
+    .nest('inner', defineSchema<AppContext>()
+        .field('whoami', (ctx) => ctx.context.userId))
+    .build();
+
+await schema.run(input, { context: { userId: 'u-42' } });
+```
+
+## Nesting
+
+`nest(key, child, options?)` accepts either a `Builder` (auto-`.build()`-ed) or an existing `Container`. The child's accumulated shape becomes `T[K]`:
+
+```typescript
+const address = defineSchema()
+    .field('city', isString)
+    .field('country', isString);
+
+const user = defineSchema()
+    .field('name', isString)
+    .nest('address', address)        // address auto-builds
+    .build();
+
+// user is Container<{ name: string; address: { city: string; country: string } }>
+```
+
+For framework integrations (e.g. mounting a routup adapter) pass the underlying `Container` instance directly.
+
+## When to use which API
+
+| Goal                                                                  | API                              |
+|-----------------------------------------------------------------------|----------------------------------|
+| Static schema, want compile-time exhaustiveness                       | `defineSchema()` builder         |
+| Dynamic mounts (loops, conditional registration, `initialize()` hook) | `new Container<T>()`             |
+| Ship a domain-scoped, reusable validator class                        | `class extends Container<T>`     |
+
+The imperative `Container` API is **not** deprecated — it remains the runtime substrate (`.build()` calls `Container.mount(...)`) and the right tool whenever the schema isn't fully known up front.
+
+## Caveats
+
+- **`oneOf()` and `T`.** A `oneOf` container's `T` stays as the **intersection** of branches, but only one branch's keys actually appear at runtime. The intersection is honest about *possible* keys; wrap with your own discriminated union when that fits better.
+- **Cross-field refinements** don't fit the per-field model. Continue to mount them either as a top-level validator on a non-content key (`.field('_invariants', crossFieldValidator)`) or as a `oneOf` branch.
+- **Group exhaustiveness.** The builder guarantees every key in `T` was registered at *build time*. It does not guarantee that, e.g., `group: 'create'` covers every required field for that group — the runtime still skips group-mismatched mounts.

--- a/docs/src/guide/container.md
+++ b/docs/src/guide/container.md
@@ -2,6 +2,10 @@
 
 `Container<T, C>` is the central type. It holds a list of mounts and exposes the `run` / `runSync` / `runParallel` / `safeRun` / `safeRunSync` methods.
 
+::: tip Looking for compile-time-typed schemas?
+[`defineSchema()`](/guide/builder) is an opt-in, type-accumulating wrapper around `Container` that derives `T` from the registered mounts — useful when the schema is fully static. The imperative `Container` API on this page remains the right tool when mounts depend on runtime conditions.
+:::
+
 ## Construction
 
 ```typescript

--- a/docs/src/guide/index.md
+++ b/docs/src/guide/index.md
@@ -32,11 +32,11 @@ type ValidatorContext<C = unknown> = {
     signal?: AbortSignal;   // run-level cancellation signal
 };
 
-type Validator<C = unknown> =
-    (ctx: ValidatorContext<C>) => Promise<unknown> | unknown;
+type Validator<C = unknown, Out = unknown> =
+    (ctx: ValidatorContext<C>) => Out | Promise<Out>;
 ```
 
-A `Validator` either returns the (optionally transformed) value or throws. Any thrown `Error` becomes an `IssueItem`; a thrown `ValidupError` contributes its `.issues` re-pathed under the parent. Both generics default to `unknown`, so call sites that don't care about typed context compile unchanged.
+A `Validator` either returns the (optionally transformed) value or throws. Any thrown `Error` becomes an `IssueItem`; a thrown `ValidupError` contributes its `.issues` re-pathed under the parent. Both generics default to `unknown`, so call sites that don't care about typed context or typed output compile unchanged. The optional second generic `Out` lets the [Builder API](/guide/builder) accumulate per-field types from validators that declare their return type.
 
 ## Issue
 
@@ -82,6 +82,7 @@ See [Run Modes](/guide/run-modes) for the trade-offs.
 ## Where to next
 
 - [Container](/guide/container) — mount semantics, registration order, nested containers.
+- [Builder API](/guide/builder) — `defineSchema()`, the opt-in compile-time-typed wrapper around `Container`.
 - [Validator](/guide/validator) — context fields, transforms, lazy schemas.
 - [Issues & Errors](/guide/issues) — structured failures, `formatIssue`, `flattenIssueItems`.
 - [Groups](/guide/groups) — `create` / `update` / custom groups from one container.

--- a/packages/standard-schema/src/module.ts
+++ b/packages/standard-schema/src/module.ts
@@ -10,9 +10,9 @@ import type { Validator, ValidatorContext } from 'validup';
 import { ValidupError } from 'validup';
 import { buildIssuesForStandardSchemaIssues } from './error';
 
-type StandardSchemaCreateFn<C = unknown> = (
+type StandardSchemaCreateFn<C, S extends StandardSchemaV1> = (
     ctx: ValidatorContext<C>,
-) => StandardSchemaV1;
+) => S;
 
 /**
  * Wrap any Standard Schema validator (zod 3.24+, valibot, arktype,
@@ -22,16 +22,23 @@ type StandardSchemaCreateFn<C = unknown> = (
  *
  * Pass a function instead of a schema to build per-context schemas
  * (e.g. depending on the active group, sibling values, or `ctx.context`).
+ *
+ * The returned validator infers its `Out` type from the schema's
+ * `StandardSchemaV1.InferOutput<S>`, so the builder API (`defineSchema`)
+ * picks up real per-field types from any Standard-Schema-compatible library.
  */
-export function createValidator<C = unknown>(
-    input: StandardSchemaV1 | StandardSchemaCreateFn<C>,
-): Validator<C> {
-    return async (ctx): Promise<unknown> => {
+export function createValidator<
+    C = unknown,
+    S extends StandardSchemaV1 = StandardSchemaV1,
+>(
+    input: S | StandardSchemaCreateFn<C, S>,
+): Validator<C, StandardSchemaV1.InferOutput<S>> {
+    return async (ctx) => {
         const schema = typeof input === 'function' ? input(ctx) : input;
         const result = await schema['~standard'].validate(ctx.value);
 
         if (!result.issues) {
-            return result.value;
+            return result.value as StandardSchemaV1.InferOutput<S>;
         }
 
         throw new ValidupError(buildIssuesForStandardSchemaIssues(result.issues));

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -171,27 +171,27 @@ The builder mirrors `Container.mount`'s keyed forms — `.mount(key, target)` an
 | Target type                        | Effect on `T`                                                           |
 |------------------------------------|-------------------------------------------------------------------------|
 | `Validator<C, Out>`                | adds `{ [K]: Awaited<Out> }` (or `{ [K]?: Awaited<Out> }` when `options.optional`) |
-| `Builder<U, C>`                    | adds `{ [K]: U }` and auto-`.build()`s the child                        |
+| `IBuilder<U, C>`                   | adds `{ [K]: U }` and auto-`.build()`s the child                        |
 | `IContainer<U, C>` (e.g. `Container<U, C>`) | adds `{ [K]: U }`                                              |
 
-`Builder` is immutable — every method returns a new builder, so chains can fork without leaking state — and `.build()` materializes a `Container<T, C>`:
+Builders are immutable — every method returns a new instance, so chains can fork without leaking state — and `.build()` materializes a `Container<T, C>`:
 
 ```typescript
-interface Builder<T extends Record<string, any>, C = unknown> {
-    mount<K extends string, V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>>(
+interface IBuilder<T extends Record<string, any>, C = unknown> {
+    mount<K extends string, V extends Validator<C, any> | IBuilder<any, C> | IContainer<any, C>>(
         key: K,
         target: V,
-    ): Builder<T & Mounted<K, V, undefined>, C>;
+    ): IBuilder<T & Mounted<K, V, undefined>, C>;
 
-    mount<K extends string, const O extends MountOptions, V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>>(
+    mount<K extends string, const O extends MountOptions, V extends Validator<C, any> | IBuilder<any, C> | IContainer<any, C>>(
         key: K,
         options: O,
         target: V,
-    ): Builder<T & Mounted<K, V, O>, C>;
+    ): IBuilder<T & Mounted<K, V, O>, C>;
 
-    oneOf(): Builder<T, C>;
-    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
-    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
+    oneOf(): IBuilder<T, C>;
+    pathsToInclude(...paths: (keyof T & string)[]): IBuilder<T, C>;
+    pathsToExclude(...paths: (keyof T & string)[]): IBuilder<T, C>;
     build(): Container<T, C>;
 }
 ```
@@ -680,7 +680,7 @@ class Container<
 ### defineSchema
 
 ```typescript
-function defineSchema<C = unknown>(): Builder<{}, C>;
+function defineSchema<C = unknown>(): IBuilder<{}, C>;
 ```
 
 See [Builder API](#builder-api-compile-time-typing). Each `.field` / `.optional` / `.nest` call returns a new builder with the accumulated shape; `.build()` materializes a `Container<T, C>`.

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -683,7 +683,7 @@ class Container<
 function defineSchema<C = unknown>(): IBuilder<{}, C>;
 ```
 
-See [Builder API](#builder-api-compile-time-typing). Each `.field` / `.optional` / `.nest` call returns a new builder with the accumulated shape; `.build()` materializes a `Container<T, C>`.
+See [Builder API](#builder-api-compile-time-typing). Each `.mount(...)` call returns a new builder with the accumulated shape; `.build()` materializes a `Container<T, C>`.
 
 ### Issue Helpers
 

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -22,6 +22,7 @@ Mount any validator function (or nested container) onto any path of your input, 
   - [Validators](#validators)
   - [Containers](#containers)
   - [Issues & Errors](#issues--errors)
+- [Builder API (compile-time typing)](#builder-api-compile-time-typing)
 - [Mounting](#mounting)
   - [Path Patterns](#path-patterns)
   - [Nested Containers](#nested-containers)
@@ -44,6 +45,7 @@ Mount any validator function (or nested container) onto any path of your input, 
   - [Issue Codes](#issue-codes)
 - [API Reference](#api-reference)
   - [Container](#container)
+  - [defineSchema](#defineschema)
   - [Issue Helpers](#issue-helpers)
   - [Type Guards](#type-guards)
 - [Integrations](#integrations)
@@ -99,7 +101,7 @@ try {
 A validator is a (sync or async) function that receives a `ValidatorContext` and either returns the validated/transformed value or throws.
 
 ```typescript
-type Validator<C = unknown> = (ctx: ValidatorContext<C>) => Promise<unknown> | unknown;
+type Validator<C = unknown, Out = unknown> = (ctx: ValidatorContext<C>) => Out | Promise<Out>;
 
 type ValidatorContext<C = unknown> = {
     key: string;            // expanded mount path within the current container
@@ -112,7 +114,7 @@ type ValidatorContext<C = unknown> = {
 };
 ```
 
-A validator's **return value** becomes the output for that path — so validators double as transformers/sanitizers.
+A validator's **return value** becomes the output for that path — so validators double as transformers/sanitizers. The optional second generic `Out` lets callers (and the [Builder API](#builder-api-compile-time-typing)) infer per-field types from the validator's return type — `Out` defaults to `unknown`, so existing call sites compile unchanged.
 
 ### Containers
 
@@ -134,6 +136,76 @@ type Issue = IssueItem | IssueGroup;
 ```
 
 This recursive structure preserves the path of failure, so consumers can render rich field-level error messages.
+
+## Builder API (compile-time typing)
+
+`new Container<T>()` happily accepts mounts that don't cover every required key of `T`, and `run()` returns `T` regardless. The TypeScript shape is a promise the runtime can't keep:
+
+```typescript
+const c = new Container<{ foo: string; bar: number }>();
+c.mount('foo', isString);          // ⚠️  bar is never validated
+const out = await c.run({});       // out: { foo, bar } — bar is undefined at runtime
+```
+
+`defineSchema()` is an opt-in, type-accumulating wrapper around `Container` that derives `T` *from the registered mounts* — so `run()`'s static return type reflects exactly what was registered:
+
+```typescript
+import { defineSchema } from 'validup';
+import { createValidator } from '@validup/zod';
+import { z } from 'zod';
+
+const schema = defineSchema()
+    .field('foo', createValidator(z.string()))   // accumulated: { foo: string }
+    .field('age', createValidator(z.number()))   // accumulated: { foo: string; age: number }
+    .build();
+
+const out = await schema.run(input);
+// out: { foo: string; age: number } — inferred, not declared
+```
+
+The integration packages' `createValidator(...)` functions (`@validup/zod`, `@validup/standard-schema`) infer the per-field `Out` type from the underlying schema, so the builder pulls real types through. Hand-written validators participate too — annotate the return type via `Validator<C, Out>` (or just write the function inline so TypeScript can infer it).
+
+`Builder` is immutable — every method returns a new builder, so chains can fork without leaking state — and `.build()` materializes a `Container<T, C>`:
+
+```typescript
+interface Builder<T extends Record<string, any>, C = unknown> {
+    field<K extends string, Out>(key: K, validator: Validator<C, Out>, options?: MountOptions): Builder<T & { [P in K]: Awaited<Out> }, C>;
+    optional<K extends string, Out>(key: K, validator: Validator<C, Out>, options?: Omit<MountOptions, 'optional'>): Builder<T & { [P in K]?: Awaited<Out> }, C>;
+    nest<K extends string, U>(key: K, child: Builder<U, C> | IContainer<U, C>, options?: MountOptions): Builder<T & { [P in K]: U }, C>;
+    oneOf(): Builder<T, C>;
+    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
+    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
+    build(): Container<T, C>;
+}
+```
+
+Pass the context type as a generic to flow it through the chain:
+
+```typescript
+type AppContext = { userId: string };
+
+const schema = defineSchema<AppContext>()
+    .field('slug', async (ctx) => {
+        // ctx.context is typed as AppContext
+        await assertSlugAvailable(ctx.value, ctx.context.userId);
+        return ctx.value;
+    })
+    .build();
+
+await schema.run(input, { context: { userId: 'u-42' } });
+```
+
+When to reach for which API:
+
+| Goal                                                               | API                                |
+|--------------------------------------------------------------------|------------------------------------|
+| Static schema, want compile-time exhaustiveness                    | `defineSchema()` builder           |
+| Dynamic mounts (loops, conditional registration, `initialize()` hook) | `new Container<T>()`            |
+| Ship a domain-scoped, reusable validator class                     | `class extends Container<T>`       |
+
+The imperative `Container` API is **not** deprecated — it remains the runtime substrate (`.build()` calls `Container.mount(...)`) and the right tool whenever the schema isn't fully known up front.
+
+> **Note on `oneOf()`** — only one branch's keys actually appear in the runtime output, but the accumulated type stays as the intersection of every branch (honest about *possible* keys). Wrap the result with your own discriminated union when that fits better.
 
 ## Mounting
 
@@ -585,6 +657,14 @@ class Container<
 | `optional`                | `MountOptions`         | Skip this mount when value is "optional"                          |
 | `optionalValue`           | `MountOptions`         | What counts as optional: `'undefined'` / `'null'` / `'falsy'`     |
 | `optionalInclude`         | `MountOptions`         | Copy optional value into the output instead of dropping it        |
+
+### defineSchema
+
+```typescript
+function defineSchema<C = unknown>(): Builder<{}, C>;
+```
+
+See [Builder API](#builder-api-compile-time-typing). Each `.field` / `.optional` / `.nest` call returns a new builder with the accumulated shape; `.build()` materializes a `Container<T, C>`.
 
 ### Issue Helpers
 

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -155,23 +155,40 @@ import { createValidator } from '@validup/zod';
 import { z } from 'zod';
 
 const schema = defineSchema()
-    .field('foo', createValidator(z.string()))   // accumulated: { foo: string }
-    .field('age', createValidator(z.number()))   // accumulated: { foo: string; age: number }
+    .mount('foo', createValidator(z.string()))                            // { foo: string }
+    .mount('age', { optional: true }, createValidator(z.number().int()))  // { foo: string; age?: number }
+    .mount('address', defineSchema().mount('city', isString))             // { …; address: { city: string } }
     .build();
 
 const out = await schema.run(input);
-// out: { foo: string; age: number } — inferred, not declared
+// out: { foo: string; age?: number; address: { city: string } } — inferred, not declared
 ```
 
 The integration packages' `createValidator(...)` functions (`@validup/zod`, `@validup/standard-schema`) infer the per-field `Out` type from the underlying schema, so the builder pulls real types through. Hand-written validators participate too — annotate the return type via `Validator<C, Out>` (or just write the function inline so TypeScript can infer it).
+
+The builder mirrors `Container.mount`'s keyed forms — `.mount(key, target)` and `.mount(key, options, target)` — and dispatches on the target type:
+
+| Target type                        | Effect on `T`                                                           |
+|------------------------------------|-------------------------------------------------------------------------|
+| `Validator<C, Out>`                | adds `{ [K]: Awaited<Out> }` (or `{ [K]?: Awaited<Out> }` when `options.optional`) |
+| `Builder<U, C>`                    | adds `{ [K]: U }` and auto-`.build()`s the child                        |
+| `IContainer<U, C>` (e.g. `Container<U, C>`) | adds `{ [K]: U }`                                              |
 
 `Builder` is immutable — every method returns a new builder, so chains can fork without leaking state — and `.build()` materializes a `Container<T, C>`:
 
 ```typescript
 interface Builder<T extends Record<string, any>, C = unknown> {
-    field<K extends string, Out>(key: K, validator: Validator<C, Out>, options?: MountOptions): Builder<T & { [P in K]: Awaited<Out> }, C>;
-    optional<K extends string, Out>(key: K, validator: Validator<C, Out>, options?: Omit<MountOptions, 'optional'>): Builder<T & { [P in K]?: Awaited<Out> }, C>;
-    nest<K extends string, U>(key: K, child: Builder<U, C> | IContainer<U, C>, options?: MountOptions): Builder<T & { [P in K]: U }, C>;
+    mount<K extends string, V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>>(
+        key: K,
+        target: V,
+    ): Builder<T & Mounted<K, V, undefined>, C>;
+
+    mount<K extends string, const O extends MountOptions, V extends Validator<C, any> | Builder<any, C> | IContainer<any, C>>(
+        key: K,
+        options: O,
+        target: V,
+    ): Builder<T & Mounted<K, V, O>, C>;
+
     oneOf(): Builder<T, C>;
     pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
     pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
@@ -179,13 +196,15 @@ interface Builder<T extends Record<string, any>, C = unknown> {
 }
 ```
 
+> **Note** — the `?`-widening on `optional: true` only fires when TypeScript sees the value as the literal `true` (or a predicate function). The `const` modifier on the second overload preserves literals from inline option objects, so the common case (`mount('email', { optional: true }, ...)`) just works. A pre-typed `MountOptions` variable whose `optional` is `boolean` will keep the field required.
+
 Pass the context type as a generic to flow it through the chain:
 
 ```typescript
 type AppContext = { userId: string };
 
 const schema = defineSchema<AppContext>()
-    .field('slug', async (ctx) => {
+    .mount('slug', async (ctx) => {
         // ctx.context is typed as AppContext
         await assertSlugAvailable(ctx.value, ctx.context.userId);
         return ctx.value;

--- a/packages/validup/src/builder/index.ts
+++ b/packages/validup/src/builder/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';
+export * from './types';

--- a/packages/validup/src/builder/module.ts
+++ b/packages/validup/src/builder/module.ts
@@ -5,14 +5,14 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { Container } from '../container';
+import { Container, isContainer } from '../container';
 import type {
     ContainerOptions,
     IContainer,
     MountOptions,
 } from '../container/types';
 import type { Validator } from '../types';
-import type { Builder } from './types';
+import type { Builder, MountTarget } from './types';
 
 type ValidatorStep<C> = {
     kind: 'validator',
@@ -34,7 +34,7 @@ function isBuilder(value: unknown): value is Builder<Record<string, any>, unknow
     return typeof value === 'object' &&
         value !== null &&
         typeof (value as { build?: unknown }).build === 'function' &&
-        typeof (value as { field?: unknown }).field === 'function';
+        typeof (value as { mount?: unknown }).mount === 'function';
 }
 
 class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
@@ -47,59 +47,42 @@ class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
         this.steps = steps;
     }
 
-    field<K extends string, Out>(
-        key: K,
-        validator: Validator<C, Out>,
-        options: MountOptions = {},
-    ): any {
-        return new BuilderImpl<any, C>(this.options, [
-            ...this.steps,
-            {
-                kind: 'validator',
-                key,
-                validator: validator as Validator<C>,
-                options,
-            },
-        ]);
-    }
+    mount(key: string, ...rest: unknown[]): any {
+        let options: MountOptions = {};
+        let target: MountTarget<C>;
 
-    optional<K extends string, Out>(
-        key: K,
-        validator: Validator<C, Out>,
-        options: Omit<MountOptions, 'optional'> = {},
-    ): any {
-        return new BuilderImpl<any, C>(this.options, [
-            ...this.steps,
-            {
-                kind: 'validator',
-                key,
-                validator: validator as Validator<C>,
-                options: { ...options, optional: true },
-            },
-        ]);
-    }
-
-    nest<K extends string, U extends Record<string, any>>(
-        key: K,
-        child: Builder<U, C> | IContainer<U, C>,
-        options: MountOptions = {},
-    ): any {
-        let container: IContainer<any, C>;
-        if (isBuilder(child)) {
-            container = (child as Builder<U, C>).build();
+        if (rest.length === 1) {
+            target = rest[0] as MountTarget<C>;
         } else {
-            container = child as IContainer<U, C>;
+            options = rest[0] as MountOptions;
+            target = rest[1] as MountTarget<C>;
         }
 
-        return new BuilderImpl<any, C>(this.options, [
-            ...this.steps,
-            {
+        let step: Step<C>;
+        if (isBuilder(target)) {
+            step = {
                 kind: 'nest',
                 key,
-                child: container,
+                child: (target as Builder<any, C>).build(),
                 options,
-            },
-        ]);
+            };
+        } else if (isContainer(target)) {
+            step = {
+                kind: 'nest',
+                key,
+                child: target as IContainer<any, C>,
+                options,
+            };
+        } else {
+            step = {
+                kind: 'validator',
+                key,
+                validator: target as Validator<C>,
+                options,
+            };
+        }
+
+        return new BuilderImpl<any, C>(this.options, [...this.steps, step]);
     }
 
     oneOf(): Builder<T, C> {
@@ -150,7 +133,7 @@ class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
 
 /**
  * Entry point for the compile-time-typed schema builder. The accumulator
- * starts at `{}` and grows as `.field`/`.optional`/`.nest` calls are chained;
+ * starts at `{}` and grows as `.mount(...)` calls are chained;
  * `.build()` returns a `Container<T, C>` whose `run()` reflects the
  * accumulated shape.
  *

--- a/packages/validup/src/builder/module.ts
+++ b/packages/validup/src/builder/module.ts
@@ -47,7 +47,7 @@ export class Builder<T extends Record<string, any>, C> implements IBuilder<T, C>
         this.steps = steps;
     }
 
-    mount(key: string, ...rest: unknown[]): any {
+    mount(key: string, ...rest: unknown[]): IBuilder<any, C> {
         let options: MountOptions = {};
         let target: MountTarget<C>;
 

--- a/packages/validup/src/builder/module.ts
+++ b/packages/validup/src/builder/module.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { Container } from '../container';
+import type {
+    ContainerOptions,
+    IContainer,
+    MountOptions,
+} from '../container/types';
+import type { Validator } from '../types';
+import type { Builder } from './types';
+
+type ValidatorStep<C> = {
+    kind: 'validator',
+    key: string,
+    validator: Validator<C>,
+    options: MountOptions,
+};
+
+type NestStep<C> = {
+    kind: 'nest',
+    key: string,
+    child: IContainer<any, C>,
+    options: MountOptions,
+};
+
+type Step<C> = ValidatorStep<C> | NestStep<C>;
+
+function isBuilder(value: unknown): value is Builder<Record<string, any>, unknown> {
+    return typeof value === 'object' &&
+        value !== null &&
+        typeof (value as { build?: unknown }).build === 'function' &&
+        typeof (value as { field?: unknown }).field === 'function';
+}
+
+class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
+    private readonly options: ContainerOptions<any>;
+
+    private readonly steps: ReadonlyArray<Step<C>>;
+
+    constructor(options: ContainerOptions<any>, steps: ReadonlyArray<Step<C>>) {
+        this.options = options;
+        this.steps = steps;
+    }
+
+    field<K extends string, Out>(
+        key: K,
+        validator: Validator<C, Out>,
+        options: MountOptions = {},
+    ): any {
+        return new BuilderImpl<any, C>(this.options, [
+            ...this.steps,
+            {
+                kind: 'validator',
+                key,
+                validator: validator as Validator<C>,
+                options,
+            },
+        ]);
+    }
+
+    optional<K extends string, Out>(
+        key: K,
+        validator: Validator<C, Out>,
+        options: Omit<MountOptions, 'optional'> = {},
+    ): any {
+        return new BuilderImpl<any, C>(this.options, [
+            ...this.steps,
+            {
+                kind: 'validator',
+                key,
+                validator: validator as Validator<C>,
+                options: { ...options, optional: true },
+            },
+        ]);
+    }
+
+    nest<K extends string, U extends Record<string, any>>(
+        key: K,
+        child: Builder<U, C> | IContainer<U, C>,
+        options: MountOptions = {},
+    ): any {
+        let container: IContainer<any, C>;
+        if (isBuilder(child)) {
+            container = (child as Builder<U, C>).build();
+        } else {
+            container = child as IContainer<U, C>;
+        }
+
+        return new BuilderImpl<any, C>(this.options, [
+            ...this.steps,
+            {
+                kind: 'nest',
+                key,
+                child: container,
+                options,
+            },
+        ]);
+    }
+
+    oneOf(): Builder<T, C> {
+        return new BuilderImpl<T, C>(
+            { ...this.options, oneOf: true },
+            this.steps,
+        );
+    }
+
+    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C> {
+        return new BuilderImpl<T, C>(
+            {
+                ...this.options,
+                pathsToInclude: [
+                    ...((this.options.pathsToInclude as string[]) ?? []),
+                    ...paths,
+                ] as ContainerOptions<any>['pathsToInclude'],
+            },
+            this.steps,
+        );
+    }
+
+    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C> {
+        return new BuilderImpl<T, C>(
+            {
+                ...this.options,
+                pathsToExclude: [
+                    ...((this.options.pathsToExclude as string[]) ?? []),
+                    ...paths,
+                ] as ContainerOptions<any>['pathsToExclude'],
+            },
+            this.steps,
+        );
+    }
+
+    build(): Container<T, C> {
+        const container = new Container<T, C>(this.options as ContainerOptions<T>);
+        for (const step of this.steps) {
+            if (step.kind === 'nest') {
+                container.mount(step.key, step.options, step.child);
+            } else {
+                container.mount(step.key, step.options, step.validator);
+            }
+        }
+        return container;
+    }
+}
+
+/**
+ * Entry point for the compile-time-typed schema builder. The accumulator
+ * starts at `{}` and grows as `.field`/`.optional`/`.nest` calls are chained;
+ * `.build()` returns a `Container<T, C>` whose `run()` reflects the
+ * accumulated shape.
+ *
+ * Pass the context type as the generic parameter to flow it through nested
+ * builders and validator factories: `defineSchema<MyContext>()`.
+ */
+export function defineSchema<C = unknown>(): Builder<{}, C> {
+    return new BuilderImpl<{}, C>({}, []);
+}

--- a/packages/validup/src/builder/module.ts
+++ b/packages/validup/src/builder/module.ts
@@ -12,7 +12,7 @@ import type {
     MountOptions,
 } from '../container/types';
 import type { Validator } from '../types';
-import type { Builder, MountTarget } from './types';
+import type { IBuilder, MountTarget } from './types';
 
 type ValidatorStep<C> = {
     kind: 'validator',
@@ -30,14 +30,14 @@ type NestStep<C> = {
 
 type Step<C> = ValidatorStep<C> | NestStep<C>;
 
-function isBuilder(value: unknown): value is Builder<Record<string, any>, unknown> {
+function isBuilder(value: unknown): value is IBuilder<Record<string, any>, unknown> {
     return typeof value === 'object' &&
         value !== null &&
         typeof (value as { build?: unknown }).build === 'function' &&
         typeof (value as { mount?: unknown }).mount === 'function';
 }
 
-class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
+export class Builder<T extends Record<string, any>, C> implements IBuilder<T, C> {
     private readonly options: ContainerOptions<any>;
 
     private readonly steps: ReadonlyArray<Step<C>>;
@@ -63,7 +63,7 @@ class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
             step = {
                 kind: 'nest',
                 key,
-                child: (target as Builder<any, C>).build(),
+                child: (target as IBuilder<any, C>).build(),
                 options,
             };
         } else if (isContainer(target)) {
@@ -82,18 +82,18 @@ class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
             };
         }
 
-        return new BuilderImpl<any, C>(this.options, [...this.steps, step]);
+        return new Builder<any, C>(this.options, [...this.steps, step]);
     }
 
-    oneOf(): Builder<T, C> {
-        return new BuilderImpl<T, C>(
+    oneOf(): IBuilder<T, C> {
+        return new Builder<T, C>(
             { ...this.options, oneOf: true },
             this.steps,
         );
     }
 
-    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C> {
-        return new BuilderImpl<T, C>(
+    pathsToInclude(...paths: (keyof T & string)[]): IBuilder<T, C> {
+        return new Builder<T, C>(
             {
                 ...this.options,
                 pathsToInclude: [
@@ -105,8 +105,8 @@ class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
         );
     }
 
-    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C> {
-        return new BuilderImpl<T, C>(
+    pathsToExclude(...paths: (keyof T & string)[]): IBuilder<T, C> {
+        return new Builder<T, C>(
             {
                 ...this.options,
                 pathsToExclude: [
@@ -140,6 +140,6 @@ class BuilderImpl<T extends Record<string, any>, C> implements Builder<T, C> {
  * Pass the context type as the generic parameter to flow it through nested
  * builders and validator factories: `defineSchema<MyContext>()`.
  */
-export function defineSchema<C = unknown>(): Builder<{}, C> {
-    return new BuilderImpl<{}, C>({}, []);
+export function defineSchema<C = unknown>(): IBuilder<{}, C> {
+    return new Builder<{}, C>({}, []);
 }

--- a/packages/validup/src/builder/types.ts
+++ b/packages/validup/src/builder/types.ts
@@ -37,14 +37,17 @@ export type IsOptional<O> = O extends { optional: true } ? true :
 /**
  * Resolved field shape produced by `mount(key, target, …)`.
  *
- * - Builder / Container target → `{ [K]: U }` where `U` is the child's shape.
- * - Validator target → `{ [K]: Awaited<Out> }`, widened to `{ [K]?: Awaited<Out> }`
- *   when `IsOptional<O>` is `true`.
+ * Builder / Container targets → `{ [K]: U }` where `U` is the child's shape.
+ * Validator targets → `{ [K]: Awaited<Out> }` based on the validator's return
+ * type. In all three cases, `IsOptional<O>` widens the property to
+ * `{ [K]?: … }` when `options.optional` is the literal `true` or a predicate —
+ * matching the runtime behavior that an optional mount may be skipped, leaving
+ * the key absent from the output.
  */
 export type Mounted<K extends string, V, O> = V extends IBuilder<infer U, any> ?
-    { [P in K]: U } :
+    IsOptional<O> extends true ? { [P in K]?: U } : { [P in K]: U } :
     V extends IContainer<infer U, any> ?
-        { [P in K]: U } :
+        IsOptional<O> extends true ? { [P in K]?: U } : { [P in K]: U } :
         V extends Validator<any, infer Out> ?
             IsOptional<O> extends true ?
                 { [P in K]?: Awaited<Out> } :
@@ -65,12 +68,14 @@ export type Mounted<K extends string, V, O> = V extends IBuilder<infer U, any> ?
 export interface IBuilder<T extends Record<string, any>, C = unknown> {
     /**
      * Mount a leaf validator, nested builder, or existing container at `key`.
-     * The accumulated shape gains the resolved type of `target`.
+     * The accumulated shape gains the resolved type of `target`. Re-mounting
+     * the same key overrides the previous registration's type (matching the
+     * runtime "last write wins" behavior of `Container.mount`).
      */
     mount<K extends string, V extends MountTarget<C>>(
         key: K,
         target: V,
-    ): IBuilder<Spread<T & Mounted<K, V, undefined>>, C>;
+    ): IBuilder<Spread<Omit<T, K> & Mounted<K, V, undefined>>, C>;
 
     /**
      * Mount with `MountOptions`. When `options.optional` is `true` (or a
@@ -84,7 +89,7 @@ export interface IBuilder<T extends Record<string, any>, C = unknown> {
         key: K,
         options: O,
         target: V,
-    ): IBuilder<Spread<T & Mounted<K, V, O>>, C>;
+    ): IBuilder<Spread<Omit<T, K> & Mounted<K, V, O>>, C>;
 
     /** Mark the resulting container as `oneOf` (only one branch must succeed). */
     oneOf(): IBuilder<T, C>;

--- a/packages/validup/src/builder/types.ts
+++ b/packages/validup/src/builder/types.ts
@@ -16,49 +16,75 @@ import type { Validator } from '../types';
 export type Spread<T> = { [K in keyof T]: T[K] };
 
 /**
- * Compile-time-typed schema builder. Each terminal method (`field`,
- * `optional`, `nest`) accumulates the resolved field type into `T`, so
- * `build()` returns a `Container<T, C>` whose static return type from
- * `run()` reflects exactly what was registered.
+ * Anything that can be mounted under a key on a `Builder`: a leaf validator,
+ * a nested builder (auto-`.build()`-ed), or an existing `Container`.
+ */
+export type MountTarget<C> = Validator<C, any> |
+    Builder<any, C> |
+    IContainer<any, C>;
+
+/**
+ * `true` when `O` declares `optional: true` or `optional: (value) => …`. The
+ * builder's `mount(key, options, target)` overload uses this to widen the
+ * accumulated key to `{ K?: V }`. Plain `boolean`-typed options stay required —
+ * the `const` modifier on the `mount` generic preserves literal `true` from
+ * inline option objects, which is the common case.
+ */
+export type IsOptional<O> = O extends { optional: true } ? true :
+    O extends { optional: (value: any) => any } ? true :
+        false;
+
+/**
+ * Resolved field shape produced by `mount(key, target, …)`.
+ *
+ * - Builder / Container target → `{ [K]: U }` where `U` is the child's shape.
+ * - Validator target → `{ [K]: Awaited<Out> }`, widened to `{ [K]?: Awaited<Out> }`
+ *   when `IsOptional<O>` is `true`.
+ */
+export type Mounted<K extends string, V, O> = V extends Builder<infer U, any> ?
+    { [P in K]: U } :
+    V extends IContainer<infer U, any> ?
+        { [P in K]: U } :
+        V extends Validator<any, infer Out> ?
+            IsOptional<O> extends true ?
+                { [P in K]?: Awaited<Out> } :
+                { [P in K]: Awaited<Out> } :
+            never;
+
+/**
+ * Compile-time-typed schema builder. `mount(...)` accumulates the resolved
+ * field type into `T`, so `build()` returns a `Container<T, C>` whose static
+ * return type from `run()` reflects exactly what was registered.
  *
  * Builders are immutable: every method returns a new `Builder` so chains
- * may fork without leaking state.
+ * may fork without leaking state. The shape of `mount` mirrors
+ * `Container.mount`'s keyed forms — `(key, target)` and
+ * `(key, options, target)` — so transferring patterns between the imperative
+ * and builder APIs is straightforward.
  */
 export interface Builder<T extends Record<string, any>, C = unknown> {
     /**
-     * Mount a leaf validator at `key`. The accumulated shape gains
-     * `{ [K]: Awaited<Out> }`. Pass a typed validator (e.g. one returned by
-     * `@validup/zod`'s `createValidator`) to flow real types through; bare
-     * `Validator<C>` validators contribute `unknown`.
+     * Mount a leaf validator, nested builder, or existing container at `key`.
+     * The accumulated shape gains the resolved type of `target`.
      */
-    field<K extends string, Out>(
+    mount<K extends string, V extends MountTarget<C>>(
         key: K,
-        validator: Validator<C, Out>,
-        options?: MountOptions,
-    ): Builder<Spread<T & { [P in K]: Awaited<Out> }>, C>;
+        target: V,
+    ): Builder<Spread<T & Mounted<K, V, undefined>>, C>;
 
     /**
-     * Mount an optional leaf validator at `key`. The accumulated shape gains
-     * `{ [K]?: Awaited<Out> }`. The `optional` mount option is set
-     * automatically; use `optionalValue` / `optionalInclude` via the third
-     * parameter if needed.
+     * Mount with `MountOptions`. When `options.optional` is `true` (or a
+     * predicate function) the accumulated key widens to `{ K?: V }`.
      */
-    optional<K extends string, Out>(
+    mount<
+        K extends string,
+        const O extends MountOptions,
+        V extends MountTarget<C>,
+    >(
         key: K,
-        validator: Validator<C, Out>,
-        options?: Omit<MountOptions, 'optional'>,
-    ): Builder<Spread<T & { [P in K]?: Awaited<Out> }>, C>;
-
-    /**
-     * Mount a nested builder/container at `key`. The accumulated shape gains
-     * `{ [K]: U }` where `U` is the child's resolved shape. Builders are
-     * `.build()`-ed automatically; passing a `Container<U, C>` works too.
-     */
-    nest<K extends string, U extends Record<string, any>>(
-        key: K,
-        child: Builder<U, C> | IContainer<U, C>,
-        options?: MountOptions,
-    ): Builder<Spread<T & { [P in K]: U }>, C>;
+        options: O,
+        target: V,
+    ): Builder<Spread<T & Mounted<K, V, O>>, C>;
 
     /** Mark the resulting container as `oneOf` (only one branch must succeed). */
     oneOf(): Builder<T, C>;

--- a/packages/validup/src/builder/types.ts
+++ b/packages/validup/src/builder/types.ts
@@ -20,7 +20,7 @@ export type Spread<T> = { [K in keyof T]: T[K] };
  * a nested builder (auto-`.build()`-ed), or an existing `Container`.
  */
 export type MountTarget<C> = Validator<C, any> |
-    Builder<any, C> |
+    IBuilder<any, C> |
     IContainer<any, C>;
 
 /**
@@ -41,7 +41,7 @@ export type IsOptional<O> = O extends { optional: true } ? true :
  * - Validator target → `{ [K]: Awaited<Out> }`, widened to `{ [K]?: Awaited<Out> }`
  *   when `IsOptional<O>` is `true`.
  */
-export type Mounted<K extends string, V, O> = V extends Builder<infer U, any> ?
+export type Mounted<K extends string, V, O> = V extends IBuilder<infer U, any> ?
     { [P in K]: U } :
     V extends IContainer<infer U, any> ?
         { [P in K]: U } :
@@ -62,7 +62,7 @@ export type Mounted<K extends string, V, O> = V extends Builder<infer U, any> ?
  * `(key, options, target)` — so transferring patterns between the imperative
  * and builder APIs is straightforward.
  */
-export interface Builder<T extends Record<string, any>, C = unknown> {
+export interface IBuilder<T extends Record<string, any>, C = unknown> {
     /**
      * Mount a leaf validator, nested builder, or existing container at `key`.
      * The accumulated shape gains the resolved type of `target`.
@@ -70,7 +70,7 @@ export interface Builder<T extends Record<string, any>, C = unknown> {
     mount<K extends string, V extends MountTarget<C>>(
         key: K,
         target: V,
-    ): Builder<Spread<T & Mounted<K, V, undefined>>, C>;
+    ): IBuilder<Spread<T & Mounted<K, V, undefined>>, C>;
 
     /**
      * Mount with `MountOptions`. When `options.optional` is `true` (or a
@@ -84,16 +84,16 @@ export interface Builder<T extends Record<string, any>, C = unknown> {
         key: K,
         options: O,
         target: V,
-    ): Builder<Spread<T & Mounted<K, V, O>>, C>;
+    ): IBuilder<Spread<T & Mounted<K, V, O>>, C>;
 
     /** Mark the resulting container as `oneOf` (only one branch must succeed). */
-    oneOf(): Builder<T, C>;
+    oneOf(): IBuilder<T, C>;
 
     /** Restrict the resulting container's `pathsToInclude`. */
-    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
+    pathsToInclude(...paths: (keyof T & string)[]): IBuilder<T, C>;
 
     /** Restrict the resulting container's `pathsToExclude`. */
-    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
+    pathsToExclude(...paths: (keyof T & string)[]): IBuilder<T, C>;
 
     /** Materialize a `Container<T, C>` and replay every accumulated mount. */
     build(): Container<T, C>;

--- a/packages/validup/src/builder/types.ts
+++ b/packages/validup/src/builder/types.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Container } from '../container';
+import type { IContainer, MountOptions } from '../container/types';
+import type { Validator } from '../types';
+
+/**
+ * Cosmetic helper — flattens an intersection so editors render
+ * `{ foo: string; bar: number }` instead of `{ foo: string } & { bar: number }`.
+ */
+export type Spread<T> = { [K in keyof T]: T[K] };
+
+/**
+ * Compile-time-typed schema builder. Each terminal method (`field`,
+ * `optional`, `nest`) accumulates the resolved field type into `T`, so
+ * `build()` returns a `Container<T, C>` whose static return type from
+ * `run()` reflects exactly what was registered.
+ *
+ * Builders are immutable: every method returns a new `Builder` so chains
+ * may fork without leaking state.
+ */
+export interface Builder<T extends Record<string, any>, C = unknown> {
+    /**
+     * Mount a leaf validator at `key`. The accumulated shape gains
+     * `{ [K]: Awaited<Out> }`. Pass a typed validator (e.g. one returned by
+     * `@validup/zod`'s `createValidator`) to flow real types through; bare
+     * `Validator<C>` validators contribute `unknown`.
+     */
+    field<K extends string, Out>(
+        key: K,
+        validator: Validator<C, Out>,
+        options?: MountOptions,
+    ): Builder<Spread<T & { [P in K]: Awaited<Out> }>, C>;
+
+    /**
+     * Mount an optional leaf validator at `key`. The accumulated shape gains
+     * `{ [K]?: Awaited<Out> }`. The `optional` mount option is set
+     * automatically; use `optionalValue` / `optionalInclude` via the third
+     * parameter if needed.
+     */
+    optional<K extends string, Out>(
+        key: K,
+        validator: Validator<C, Out>,
+        options?: Omit<MountOptions, 'optional'>,
+    ): Builder<Spread<T & { [P in K]?: Awaited<Out> }>, C>;
+
+    /**
+     * Mount a nested builder/container at `key`. The accumulated shape gains
+     * `{ [K]: U }` where `U` is the child's resolved shape. Builders are
+     * `.build()`-ed automatically; passing a `Container<U, C>` works too.
+     */
+    nest<K extends string, U extends Record<string, any>>(
+        key: K,
+        child: Builder<U, C> | IContainer<U, C>,
+        options?: MountOptions,
+    ): Builder<Spread<T & { [P in K]: U }>, C>;
+
+    /** Mark the resulting container as `oneOf` (only one branch must succeed). */
+    oneOf(): Builder<T, C>;
+
+    /** Restrict the resulting container's `pathsToInclude`. */
+    pathsToInclude(...paths: (keyof T & string)[]): Builder<T, C>;
+
+    /** Restrict the resulting container's `pathsToExclude`. */
+    pathsToExclude(...paths: (keyof T & string)[]): Builder<T, C>;
+
+    /** Materialize a `Container<T, C>` and replay every accumulated mount. */
+    build(): Container<T, C>;
+}

--- a/packages/validup/src/index.ts
+++ b/packages/validup/src/index.ts
@@ -10,5 +10,6 @@ export * from './constants';
 export * from './error';
 export * from './issue';
 export * from './container';
+export * from './builder';
 export * from './types';
 export * from './utils';

--- a/packages/validup/src/types.ts
+++ b/packages/validup/src/types.ts
@@ -49,4 +49,14 @@ export type ValidatorContext<C = unknown> = {
     signal?: AbortSignal
 };
 
-export type Validator<C = unknown> = (ctx: ValidatorContext<C>) => Promise<unknown> | unknown;
+/**
+ * A `Validator` either returns the (optionally transformed) value or throws.
+ *
+ * @typeParam C   - Caller-supplied context type, propagated from the parent
+ *                  `Container<T, C>` and surfaced on `ValidatorContext.context`.
+ * @typeParam Out - The validator's resolved output type. Defaults to `unknown`,
+ *                  so call sites that don't care about typed output compile
+ *                  unchanged. The builder API (`defineSchema`) uses this
+ *                  second generic to accumulate per-field types.
+ */
+export type Validator<C = unknown, Out = unknown> = (ctx: ValidatorContext<C>) => Out | Promise<Out>;

--- a/packages/validup/test/unit/builder.spec.ts
+++ b/packages/validup/test/unit/builder.spec.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    assertType,
+    describe,
+    expect,
+    expectTypeOf,
+    it,
+} from 'vitest';
+import {
+    Container,
+    type Validator,
+    ValidupError,
+    defineSchema,
+} from '../../src';
+
+const stringValidator: Validator<unknown, string> = (ctx) => {
+    if (typeof ctx.value !== 'string') {
+        throw new Error('Value is not a string');
+    }
+    return ctx.value;
+};
+
+const numberValidator: Validator<unknown, number> = (ctx) => {
+    if (typeof ctx.value !== 'number') {
+        throw new Error('Value is not a number');
+    }
+    return ctx.value;
+};
+
+describe('src/builder', () => {
+    it('builds a Container that runs accumulated mounts', async () => {
+        const schema = defineSchema()
+            .field('foo', stringValidator)
+            .field('bar', numberValidator)
+            .build();
+
+        expect(schema).toBeInstanceOf(Container);
+
+        const out = await schema.run({ foo: 'hello', bar: 42 });
+
+        expect(out).toEqual({ foo: 'hello', bar: 42 });
+        expectTypeOf(out).toEqualTypeOf<{ foo: string, bar: number }>();
+    });
+
+    it('treats every method call as immutable', () => {
+        const a = defineSchema().field('foo', stringValidator);
+        const b = a.field('bar', numberValidator);
+
+        const aBuilt = a.build();
+        const bBuilt = b.build();
+
+        // The two builds should hold a different number of mounts — i.e. `a`
+        // wasn't mutated when `b` was derived.
+        expect((aBuilt as any).items.length).toEqual(1);
+        expect((bBuilt as any).items.length).toEqual(2);
+    });
+
+    it('reflects the accumulated shape on optional() with `?` widening', async () => {
+        const schema = defineSchema()
+            .field('foo', stringValidator)
+            .optional('bar', numberValidator)
+            .build();
+
+        const present = await schema.run({ foo: 'x', bar: 1 });
+        expectTypeOf(present).toEqualTypeOf<{ foo: string, bar?: number }>();
+        expect(present).toEqual({ foo: 'x', bar: 1 });
+
+        const missing = await schema.run({ foo: 'x' });
+        // optional bar drops out of the object when missing
+        expect(missing).toEqual({ foo: 'x' });
+    });
+
+    it('forwards optionalValue / optionalInclude through optional()', async () => {
+        const schema = defineSchema()
+            .optional('bar', numberValidator, {
+                optionalValue: 'null',
+                optionalInclude: true,
+            })
+            .build();
+
+        const out = await schema.run({ bar: null });
+        expect(out).toEqual({ bar: null });
+    });
+
+    it('nests a child builder and merges the shape', async () => {
+        const parent = defineSchema()
+            .field('id', stringValidator)
+            .nest('child', defineSchema()
+                .field('age', numberValidator))
+            .build();
+
+        const out = await parent.run({ id: 'p', child: { age: 30 } });
+
+        expect(out).toEqual({ id: 'p', child: { age: 30 } });
+        expectTypeOf(out).toEqualTypeOf<{
+            id: string,
+            child: { age: number },
+        }>();
+    });
+
+    it('also accepts a Container as a nest() target', async () => {
+        const child = new Container<{ age: number }>();
+        child.mount('age', numberValidator);
+
+        const parent = defineSchema()
+            .field('id', stringValidator)
+            .nest('child', child)
+            .build();
+
+        const out = await parent.run({ id: 'p', child: { age: 12 } });
+        expect(out).toEqual({ id: 'p', child: { age: 12 } });
+    });
+
+    it('toggles oneOf and produces a single ONE_OF_FAILED group when every branch fails', async () => {
+        const schema = defineSchema()
+            .field('foo', stringValidator)
+            .field('bar', numberValidator)
+            .oneOf()
+            .build();
+
+        // both branches happy — passes (only one needs to)
+        await expect(schema.run({ foo: 'a', bar: 1 })).resolves.toBeDefined();
+
+        // both branches angry — fails as oneOf group
+        try {
+            await schema.run({ foo: 1, bar: 'no' });
+            throw new Error('expected ValidupError');
+        } catch (e) {
+            expect(e).toBeInstanceOf(ValidupError);
+            if (e instanceof ValidupError) {
+                expect(e.issues).toHaveLength(1);
+                expect(e.issues[0].type).toEqual('group');
+                if (e.issues[0].type === 'group') {
+                    expect(e.issues[0].code).toEqual('one_of_failed');
+                    expect(e.issues[0].issues.length).toBeGreaterThanOrEqual(2);
+                }
+            }
+        }
+
+        // first happy — succeeds (oneOf passes if at least one succeeded)
+        const out = await schema.run({ foo: 'a', bar: 'no' });
+        expect(out.foo).toEqual('a');
+    });
+
+    it('forwards pathsToInclude/pathsToExclude to the underlying Container', async () => {
+        const included = defineSchema()
+            .field('foo', stringValidator)
+            .field('bar', numberValidator)
+            .pathsToInclude('foo')
+            .build();
+
+        // bar would normally throw because the value is not a number, but
+        // pathsToInclude limits execution to `foo` only.
+        const out = await included.run({ foo: 'a', bar: 'not-a-number' });
+        expect(out.foo).toEqual('a');
+
+        const excluded = defineSchema()
+            .field('foo', stringValidator)
+            .field('bar', numberValidator)
+            .pathsToExclude('bar')
+            .build();
+
+        const out2 = await excluded.run({ foo: 'b', bar: 'not-a-number' });
+        expect(out2.foo).toEqual('b');
+    });
+
+    it('infers Out from validators', () => {
+        const schema = defineSchema()
+            .field('s', stringValidator)
+            .field('n', numberValidator)
+            .build();
+
+        // run() return type reflects the registered shape — type-only check.
+        type RunResult = Awaited<ReturnType<typeof schema.run>>;
+        expectTypeOf<RunResult>().toEqualTypeOf<{ s: string, n: number }>();
+    });
+
+    it('threads context through validators and nest()', async () => {
+        type AppCtx = { user: string };
+
+        const validator: Validator<AppCtx, string> = (ctx) => {
+            assertType<AppCtx>(ctx.context);
+            return ctx.context.user;
+        };
+
+        const schema = defineSchema<AppCtx>()
+            .field('whoami', validator)
+            .nest('inner', defineSchema<AppCtx>()
+                .field('whoami', validator))
+            .build();
+
+        const out = await schema.run({}, { context: { user: 'peter' } });
+        expect(out).toEqual({
+            whoami: 'peter',
+            inner: { whoami: 'peter' },
+        });
+    });
+
+    it('produces a ValidupError when a registered field rejects', async () => {
+        const schema = defineSchema()
+            .field('foo', stringValidator)
+            .build();
+
+        expect.assertions(2);
+        try {
+            await schema.run({ foo: 1 });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                expect(e.issues).toHaveLength(1);
+                expect(e.issues[0].path).toEqual(['foo']);
+            }
+        }
+    });
+
+    it('ignores keys that were not registered (no compile-time enforcement at runtime)', async () => {
+        const schema = defineSchema()
+            .field('foo', stringValidator)
+            .build();
+
+        // `bar` was never registered — runtime simply doesn't visit it.
+        const out = await schema.run({ foo: 'x', bar: 'unused' } as any);
+        expect(out).toEqual({ foo: 'x' });
+    });
+});

--- a/packages/validup/test/unit/builder.spec.ts
+++ b/packages/validup/test/unit/builder.spec.ts
@@ -243,6 +243,48 @@ describe('src/builder', () => {
         }
     });
 
+    it('widens optional nested builder to optional in T', () => {
+        const child = defineSchema()
+            .mount('city', stringValidator);
+
+        const schema = defineSchema()
+            .mount('address', { optional: true }, child)
+            .build();
+
+        type R = Awaited<ReturnType<typeof schema.run>>;
+        expectTypeOf<R>().toEqualTypeOf<{ address?: { city: string } }>();
+    });
+
+    it('widens optional nested Container to optional in T', () => {
+        const child = new Container<{ city: string }>();
+        child.mount('city', stringValidator);
+
+        const schema = defineSchema()
+            .mount('address', { optional: true }, child)
+            .build();
+
+        type R = Awaited<ReturnType<typeof schema.run>>;
+        expectTypeOf<R>().toEqualTypeOf<{ address?: { city: string } }>();
+    });
+
+    it('overrides previous mount type when remounting the same key (last write wins)', async () => {
+        // sanitize-then-validate: both mounts succeed; the second's Out becomes T[K]
+        const passthrough: Validator<unknown, string> = (ctx) => String(ctx.value);
+        const toNumber: Validator<unknown, number> = (ctx) => Number(ctx.value);
+
+        const schema = defineSchema()
+            .mount('foo', passthrough)  // would type foo as string
+            .mount('foo', toNumber)     // overrides — final type is number
+            .build();
+
+        type R = Awaited<ReturnType<typeof schema.run>>;
+        expectTypeOf<R>().toEqualTypeOf<{ foo: number }>();
+
+        // Runtime: second mount reads output[foo] from the first, writes last.
+        const out = await schema.run({ foo: '42' });
+        expect(out).toEqual({ foo: 42 });
+    });
+
     it('ignores keys that were not registered (no compile-time enforcement at runtime)', async () => {
         const schema = defineSchema()
             .mount('foo', stringValidator)

--- a/packages/validup/test/unit/builder.spec.ts
+++ b/packages/validup/test/unit/builder.spec.ts
@@ -36,8 +36,8 @@ const numberValidator: Validator<unknown, number> = (ctx) => {
 describe('src/builder', () => {
     it('builds a Container that runs accumulated mounts', async () => {
         const schema = defineSchema()
-            .field('foo', stringValidator)
-            .field('bar', numberValidator)
+            .mount('foo', stringValidator)
+            .mount('bar', numberValidator)
             .build();
 
         expect(schema).toBeInstanceOf(Container);
@@ -49,8 +49,8 @@ describe('src/builder', () => {
     });
 
     it('treats every method call as immutable', () => {
-        const a = defineSchema().field('foo', stringValidator);
-        const b = a.field('bar', numberValidator);
+        const a = defineSchema().mount('foo', stringValidator);
+        const b = a.mount('bar', numberValidator);
 
         const aBuilt = a.build();
         const bBuilt = b.build();
@@ -61,10 +61,10 @@ describe('src/builder', () => {
         expect((bBuilt as any).items.length).toEqual(2);
     });
 
-    it('reflects the accumulated shape on optional() with `?` widening', async () => {
+    it('widens the accumulated shape when options.optional is true', async () => {
         const schema = defineSchema()
-            .field('foo', stringValidator)
-            .optional('bar', numberValidator)
+            .mount('foo', stringValidator)
+            .mount('bar', { optional: true }, numberValidator)
             .build();
 
         const present = await schema.run({ foo: 'x', bar: 1 });
@@ -76,23 +76,48 @@ describe('src/builder', () => {
         expect(missing).toEqual({ foo: 'x' });
     });
 
-    it('forwards optionalValue / optionalInclude through optional()', async () => {
+    it('forwards optionalValue / optionalInclude alongside optional', async () => {
         const schema = defineSchema()
-            .optional('bar', numberValidator, {
+            .mount('bar', {
+                optional: true,
                 optionalValue: 'null',
                 optionalInclude: true,
-            })
+            }, numberValidator)
             .build();
 
         const out = await schema.run({ bar: null });
         expect(out).toEqual({ bar: null });
     });
 
+    it('widens to optional when options.optional is a predicate function', async () => {
+        const schema = defineSchema()
+            .mount('bar', { optional: (v) => v === '' || typeof v === 'undefined' }, stringValidator)
+            .build();
+
+        const out = await schema.run({});
+        expect(out).toEqual({});
+        // Type-only: predicate optional should still surface as `bar?`
+        type R = Awaited<ReturnType<typeof schema.run>>;
+        expectTypeOf<R>().toEqualTypeOf<{ bar?: string }>();
+    });
+
+    it('keeps the accumulated key required when options.optional is omitted', async () => {
+        const schema = defineSchema()
+            .mount('bar', { group: 'create' }, stringValidator)
+            .build();
+
+        type R = Awaited<ReturnType<typeof schema.run>>;
+        expectTypeOf<R>().toEqualTypeOf<{ bar: string }>();
+
+        const out = await schema.run({ bar: 'x' }, { group: 'create' });
+        expect(out).toEqual({ bar: 'x' });
+    });
+
     it('nests a child builder and merges the shape', async () => {
         const parent = defineSchema()
-            .field('id', stringValidator)
-            .nest('child', defineSchema()
-                .field('age', numberValidator))
+            .mount('id', stringValidator)
+            .mount('child', defineSchema()
+                .mount('age', numberValidator))
             .build();
 
         const out = await parent.run({ id: 'p', child: { age: 30 } });
@@ -104,13 +129,13 @@ describe('src/builder', () => {
         }>();
     });
 
-    it('also accepts a Container as a nest() target', async () => {
+    it('also accepts a Container as a mount target', async () => {
         const child = new Container<{ age: number }>();
         child.mount('age', numberValidator);
 
         const parent = defineSchema()
-            .field('id', stringValidator)
-            .nest('child', child)
+            .mount('id', stringValidator)
+            .mount('child', child)
             .build();
 
         const out = await parent.run({ id: 'p', child: { age: 12 } });
@@ -119,8 +144,8 @@ describe('src/builder', () => {
 
     it('toggles oneOf and produces a single ONE_OF_FAILED group when every branch fails', async () => {
         const schema = defineSchema()
-            .field('foo', stringValidator)
-            .field('bar', numberValidator)
+            .mount('foo', stringValidator)
+            .mount('bar', numberValidator)
             .oneOf()
             .build();
 
@@ -150,8 +175,8 @@ describe('src/builder', () => {
 
     it('forwards pathsToInclude/pathsToExclude to the underlying Container', async () => {
         const included = defineSchema()
-            .field('foo', stringValidator)
-            .field('bar', numberValidator)
+            .mount('foo', stringValidator)
+            .mount('bar', numberValidator)
             .pathsToInclude('foo')
             .build();
 
@@ -161,8 +186,8 @@ describe('src/builder', () => {
         expect(out.foo).toEqual('a');
 
         const excluded = defineSchema()
-            .field('foo', stringValidator)
-            .field('bar', numberValidator)
+            .mount('foo', stringValidator)
+            .mount('bar', numberValidator)
             .pathsToExclude('bar')
             .build();
 
@@ -172,8 +197,8 @@ describe('src/builder', () => {
 
     it('infers Out from validators', () => {
         const schema = defineSchema()
-            .field('s', stringValidator)
-            .field('n', numberValidator)
+            .mount('s', stringValidator)
+            .mount('n', numberValidator)
             .build();
 
         // run() return type reflects the registered shape — type-only check.
@@ -181,7 +206,7 @@ describe('src/builder', () => {
         expectTypeOf<RunResult>().toEqualTypeOf<{ s: string, n: number }>();
     });
 
-    it('threads context through validators and nest()', async () => {
+    it('threads context through validators and nested builders', async () => {
         type AppCtx = { user: string };
 
         const validator: Validator<AppCtx, string> = (ctx) => {
@@ -190,9 +215,9 @@ describe('src/builder', () => {
         };
 
         const schema = defineSchema<AppCtx>()
-            .field('whoami', validator)
-            .nest('inner', defineSchema<AppCtx>()
-                .field('whoami', validator))
+            .mount('whoami', validator)
+            .mount('inner', defineSchema<AppCtx>()
+                .mount('whoami', validator))
             .build();
 
         const out = await schema.run({}, { context: { user: 'peter' } });
@@ -204,7 +229,7 @@ describe('src/builder', () => {
 
     it('produces a ValidupError when a registered field rejects', async () => {
         const schema = defineSchema()
-            .field('foo', stringValidator)
+            .mount('foo', stringValidator)
             .build();
 
         expect.assertions(2);
@@ -220,7 +245,7 @@ describe('src/builder', () => {
 
     it('ignores keys that were not registered (no compile-time enforcement at runtime)', async () => {
         const schema = defineSchema()
-            .field('foo', stringValidator)
+            .mount('foo', stringValidator)
             .build();
 
         // `bar` was never registered — runtime simply doesn't visit it.

--- a/packages/zod/src/module.ts
+++ b/packages/zod/src/module.ts
@@ -7,27 +7,31 @@
 
 import type { Validator, ValidatorContext } from 'validup';
 import { ValidupError } from 'validup';
-import type { ZodType } from 'zod';
+import type { output as ZodOutput, ZodType } from 'zod';
 import { buildIssuesForZodError } from './error';
 
-type ZodCreateFn<C = unknown> = (ctx: ValidatorContext<C>) => ZodType;
+type ZodCreateFn<C, Z extends ZodType> = (ctx: ValidatorContext<C>) => Z;
 
-export function createValidator<C = unknown>(input: ZodCreateFn<C> | ZodType) : Validator<C> {
-    return async (ctx): Promise<unknown> => {
-        let zod : ZodType;
-        if (typeof input === 'function') {
-            zod = input(ctx);
-        } else {
-            zod = input;
-        }
+/**
+ * Wrap a zod schema as a validup `Validator`. The returned validator infers
+ * its `Out` type from the schema, so the builder API (`defineSchema`) and any
+ * caller using the second `Validator<C, Out>` generic see the parsed shape
+ * (`z.output<Z>`) rather than `unknown`.
+ *
+ * Pass a factory `(ctx) => schema` to build per-context schemas.
+ */
+export function createValidator<
+    C = unknown,
+    Z extends ZodType = ZodType,
+>(input: Z | ZodCreateFn<C, Z>): Validator<C, ZodOutput<Z>> {
+    return async (ctx) => {
+        const zod = typeof input === 'function' ? input(ctx) : input;
 
         const outcome = await zod.safeParseAsync(ctx.value);
         if (outcome.success) {
-            return outcome.data;
+            return outcome.data as ZodOutput<Z>;
         }
 
-        const issues = buildIssuesForZodError(outcome.error);
-
-        throw new ValidupError(issues);
+        throw new ValidupError(buildIssuesForZodError(outcome.error));
     };
 }


### PR DESCRIPTION
## Summary

Closes the last open item in `improvements.md` — gives `Container<T, C>` a compile-time-typed counterpart and threads validator return types through the integration adapters.

- **`Validator<C, Out = unknown>`** — second generic on `Validator`. Default keeps every existing call site source-compatible.
- **Adapter inference** — `@validup/zod`'s `createValidator` now infers `Out = z.output<Schema>`; `@validup/standard-schema` infers `Out = StandardSchemaV1.InferOutput<Schema>`. `@validup/express-validator` keeps `Out = unknown` (its return value is typed `any`).
- **`defineSchema()` builder** — opt-in, type-accumulating wrapper around `Container` (new module under `packages/validup/src/builder/`). Each `.field` / `.optional` / `.nest` call accumulates the resolved shape; `.build()` returns a `Container<T, C>` whose `run()`'s static return type matches exactly what was registered. Builders are immutable. `.oneOf` / `.pathsToInclude` / `.pathsToExclude` are container-level switches that don't add fields.

The imperative `Container` API stays for dynamic mounts, multi-group remount patterns, and the protected `initialize()` subclass hook — they don't overlap.

## Docs

- New "Builder API (compile-time typing)" section in `packages/validup/README.md` + a `defineSchema` entry in the API reference.
- New VitePress guide page at `docs/src/guide/builder.md`, slotted into the sidebar and cross-linked from `/guide/` and `/guide/container`.
- Root README "Type-safe" row mentions the builder.
- `.agents/conventions.md` gains a "Documentation surfaces" section (separate commit) requiring future code/tooling changes to update READMEs + VitePress + agent docs in the same pass.

## Test plan

- [x] `npm run build` — green across all 7 projects (validup core + 5 adapters + docs)
- [x] `npm run lint` — clean
- [x] `npm test` — 99 specs in core (12 new in `builder.spec.ts`), all adapter packages still pass
- [x] `cd docs && npm run build` — VitePress site builds cleanly with the new page
- [ ] Manual: `defineSchema().field('foo', createValidator(z.string())).build()` typechecks and `run()` returns `{ foo: string }` in a downstream project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in Builder API for compile-time schema composition with automatic output-type accumulation.
  * Validator types now support an optional output generic for stronger per-path inference.
  * Builder exports made public for consumers.

* **Documentation**
  * Full Builder API guide, updated validator docs, sidebar entry, README clarifications, and documentation-surface guidelines.

* **Tests**
  * Added comprehensive unit tests covering Builder API behavior and type/runtime interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->