### PR TITLE
fix: address audit findings blocking 0.3.0 release

### DIFF
--- a/packages/express-validator/package.json
+++ b/packages/express-validator/package.json
@@ -37,8 +37,7 @@
     "keywords": [],
     "license": "Apache-2.0",
     "dependencies": {
-        "validup": "^0.2.2",
-        "smob": "^1.6.2"
+        "validup": "^0.2.2"
     },
     "devDependencies": {
         "express-validator": "^7.3.1"

--- a/packages/express-validator/src/error.ts
+++ b/packages/express-validator/src/error.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
@@ -7,46 +7,110 @@
 
 import type { ValidationError } from 'express-validator/lib/base';
 import type { Issue } from 'validup';
-import { defineIssueItem } from 'validup';
+import { IssueCode, defineIssueGroup, defineIssueItem } from 'validup';
 
-function buildIssuesForError(
-    error: ValidationError,
-) : Issue[] {
-    const output : Issue[] = [];
-    switch (error.type) {
-        case 'field': {
-            output.push(defineIssueItem({
-                path: error.path ? [error.path] : [],
-                received: error.value,
-                message: error.msg,
-            }));
-            break;
-        }
-        case 'alternative': {
-            for (let i = 0; i < error.nestedErrors.length; i++) {
-                output.push(...buildIssuesForError(error.nestedErrors[i]));
-            }
-            break;
-        }
-        case 'alternative_grouped': {
-            for (let i = 0; i < error.nestedErrors.length; i++) {
-                for (let j = 0; j < error.nestedErrors[i].length; j++) {
-                    output.push(...buildIssuesForError(error.nestedErrors[i][j]));
-                }
-            }
-        }
+/**
+ * Split express-validator's dotted/bracketed path string (`"address.city"`,
+ * `"tags[0].name"`) into a flat `PropertyKey[]` so consumers can walk it
+ * uniformly with validup's other issue paths. Numeric bracket segments are
+ * coerced to `number` to match the convention used by `pathtrace`.
+ */
+function splitPath(path: string): PropertyKey[] {
+    if (!path) {
+        return [];
     }
 
-    return output;
+    const segments: PropertyKey[] = [];
+    let cursor = 0;
+    const len = path.length;
+
+    while (cursor < len) {
+        if (path[cursor] === '.') {
+            cursor++;
+            continue;
+        }
+
+        if (path[cursor] === '[') {
+            const end = path.indexOf(']', cursor + 1);
+            if (end === -1) {
+                // Malformed path — give up and treat the remainder verbatim.
+                segments.push(path.slice(cursor));
+                break;
+            }
+            const raw = path.slice(cursor + 1, end);
+            // Numeric bracket indices become numbers; quoted/string keys stay
+            // strings (with the surrounding quotes stripped).
+            if (/^\d+$/.test(raw)) {
+                segments.push(Number(raw));
+            } else {
+                segments.push(raw.replace(/^['"]|['"]$/g, ''));
+            }
+            cursor = end + 1;
+            continue;
+        }
+
+        let next = cursor;
+        while (next < len && path[next] !== '.' && path[next] !== '[') {
+            next++;
+        }
+        segments.push(path.slice(cursor, next));
+        cursor = next;
+    }
+
+    return segments;
 }
 
-export function buildIssuesForErrors(
-    errors: ValidationError[],
-): Issue[] {
-    const issues : Issue[] = [];
+function buildIssuesForError(error: ValidationError): Issue[] {
+    switch (error.type) {
+        case 'field': {
+            return [defineIssueItem({
+                path: splitPath(error.path),
+                received: error.value,
+                message: typeof error.msg === 'string' ? error.msg : String(error.msg),
+            })];
+        }
+        case 'alternative': {
+            // `oneOf()` chain — every branch failed. Wrap the per-branch field
+            // errors in a group so consumers can tell this apart from a flat
+            // list of independent field errors.
+            return [defineIssueGroup({
+                code: IssueCode.ONE_OF_FAILED,
+                message: typeof error.msg === 'string' ? error.msg : String(error.msg),
+                path: [],
+                issues: error.nestedErrors.flatMap((nested) => buildIssuesForError(nested)),
+            })];
+        }
+        case 'alternative_grouped': {
+            // `oneOf({ errorType: 'grouped' })` — each branch's errors are
+            // kept under a sub-group so consumers can recover the per-branch
+            // structure (useful for surfacing "branch N failed because …").
+            return [defineIssueGroup({
+                code: IssueCode.ONE_OF_FAILED,
+                message: typeof error.msg === 'string' ? error.msg : String(error.msg),
+                path: [],
+                issues: error.nestedErrors.map((group, index) => defineIssueGroup({
+                    message: `Alternative ${index + 1} failed`,
+                    path: [],
+                    params: { alternative: index },
+                    issues: group.flatMap((nested) => buildIssuesForError(nested)),
+                })),
+            })];
+        }
+        default: {
+            // `unknown_fields` — no per-field path; surface as a root-level
+            // item carrying the message so it isn't silently swallowed.
+            return [defineIssueItem({
+                path: [],
+                message: typeof error.msg === 'string' ? error.msg : String(error.msg),
+            })];
+        }
+    }
+}
+
+export function buildIssuesForErrors(errors: readonly ValidationError[]): Issue[] {
+    const issues: Issue[] = [];
     for (const error of errors) {
         issues.push(...buildIssuesForError(error));
     }
-
     return issues;
 }

--- a/packages/express-validator/src/module.ts
+++ b/packages/express-validator/src/module.ts
@@ -1,12 +1,11 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { ContextRunner, FieldValidationError } from 'express-validator';
-import { distinctArray } from 'smob';
+import type { ContextRunner } from 'express-validator';
 import type { Issue, Validator, ValidatorContext } from 'validup';
 import { ValidupError } from 'validup';
 import { buildIssuesForErrors } from './error';
@@ -19,32 +18,31 @@ export function createValidator<C = unknown>(
     input: ContextRunnerCreateFn<C> | ContextRunner,
 ) : Validator<C> {
     return async (ctx): Promise<unknown> => {
-        let runner : ContextRunner;
-        if (typeof input === 'function') {
-            runner = input(ctx);
-        } else {
-            runner = input;
-        }
+        const runner: ContextRunner = typeof input === 'function' ? input(ctx) : input;
 
         const outcome = await runner.run({ body: ctx.value });
 
-        const issues : Issue[] = [];
+        // Translate every error reported by the chain — including `alternative`
+        // and `alternative_grouped` shapes, which the previous implementation
+        // filtered out by matching only `type === 'field'` against the first
+        // selected field.
+        const issues: Issue[] = buildIssuesForErrors(
+            outcome.context.errors as Parameters<typeof buildIssuesForErrors>[0],
+        );
 
-        const [field] = outcome.context.getData({ requiredOnly: false });
-        if (field) {
-            const errors = distinctArray(outcome.context.errors.filter(
-                (error) => error.type === 'field' &&
-                    error.location === field.location &&
-                    error.path === field.path,
-            ) as FieldValidationError[]);
-
-            if (errors.length > 0) {
-                issues.push(...buildIssuesForErrors(errors));
-            } else {
-                return field.value;
-            }
+        if (issues.length > 0) {
+            throw new ValidupError(issues);
         }
 
-        throw new ValidupError(issues);
+        // No errors — return the (possibly sanitized) value. Express-validator
+        // mutates `FieldInstance.value` in place as sanitizers run, so
+        // `field.value` reflects post-sanitizer state. When the chain selects a
+        // single field we forward that; otherwise the chain doesn't designate
+        // a primary value, so fall back to the original input.
+        const fields = outcome.context.getData({ requiredOnly: false });
+        if (fields.length === 1) {
+            return fields[0].value;
+        }
+        return ctx.value;
     };
 }

--- a/packages/express-validator/test/unit/error.spec.ts
+++ b/packages/express-validator/test/unit/error.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { body, oneOf } from 'express-validator';
+import {
+    Container,
+    IssueCode,
+    ValidupError,
+    flattenIssueItems,
+    isIssueGroup,
+} from 'validup';
+import { createValidator } from '../../src';
+
+describe('error translation', () => {
+    it('should split dotted/bracketed field paths into PropertyKey[]', async () => {
+        // Regression: error.ts previously emitted `path: [error.path]`, leaving
+        // dotted strings unsplit. Per Issue.path's contract, segments are
+        // separate elements (numeric for bracket indices).
+        const container = new Container();
+        container.mount('user', createValidator(() => body('user.address.city').isString()));
+
+        expect.assertions(2);
+        try {
+            await container.run({ user: { address: { city: 42 } } });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                const items = flattenIssueItems(e.issues);
+                expect(items).toHaveLength(1);
+                // Parent prefix 'user' from the mount + split chain path.
+                expect(items[0].path).toEqual(['user', 'user', 'address', 'city']);
+            }
+        }
+    });
+
+    it('should split bracketed numeric indices into numbers', async () => {
+        const container = new Container();
+        container.mount('list', createValidator(() => body('items[0].name').isString()));
+
+        expect.assertions(1);
+        try {
+            await container.run({ list: { items: [{ name: 1 }] } });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                const items = flattenIssueItems(e.issues);
+                // The '0' segment is a number, not the string '0'.
+                expect(items[0].path).toEqual(['list', 'items', 0, 'name']);
+            }
+        }
+    });
+
+    it('should not drop errors past the first selected field', async () => {
+        // Regression: the adapter previously read `const [field] = getData()`
+        // and matched errors against that single field, silently dropping
+        // every other field's validation outcome.
+        const container = new Container();
+        container.mount(
+            'group',
+            createValidator(() => body(['a', 'b']).isString()),
+        );
+
+        expect.assertions(2);
+        try {
+            await container.run({ group: { a: 1, b: 2 } });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                const items = flattenIssueItems(e.issues);
+                // Both fields surface, not just one.
+                const paths = items.map((i) => i.path.join('.')).sort();
+                expect(paths.length).toBeGreaterThanOrEqual(2);
+                expect(paths.some((p) => p.endsWith('.a')) &&
+                    paths.some((p) => p.endsWith('.b'))).toBe(true);
+            }
+        }
+    });
+
+    it('should wrap alternative errors in an IssueGroup with ONE_OF_FAILED', async () => {
+        // Regression: `alternative` / `alternative_grouped` were filtered out
+        // entirely by the `error.type === 'field'` check. Now they surface as
+        // an IssueGroup so consumers can distinguish a oneOf failure from a
+        // flat list of independent field errors.
+        const container = new Container();
+        container.mount('val', createValidator(() => oneOf([
+            body('val').isString(),
+            body('val').isInt(),
+        ])));
+
+        expect.assertions(2);
+        try {
+            await container.run({ val: { not: 'either' } });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                // The mount path is 'val', so recordMountError wraps the
+                // adapter's IssueGroup into another group keyed by 'val'.
+                // Either way, somewhere in the tree there is a group carrying
+                // ONE_OF_FAILED.
+                const stack = [...e.issues];
+                let foundOneOf = false;
+                let foundLeafError = false;
+                while (stack.length > 0) {
+                    const issue = stack.pop()!;
+                    if (isIssueGroup(issue)) {
+                        if (issue.code === IssueCode.ONE_OF_FAILED) {
+                            foundOneOf = true;
+                        }
+                        stack.push(...issue.issues);
+                    } else {
+                        foundLeafError = true;
+                    }
+                }
+                expect(foundOneOf).toBe(true);
+                expect(foundLeafError).toBe(true);
+            }
+        }
+    });
+
+    it('should return the sanitized value when a single-field chain succeeds', async () => {
+        // express-validator mutates `FieldInstance.value` as sanitizers run
+        // (see Context.setData). The adapter forwards that post-sanitizer
+        // value upstream when the chain selects a single field.
+        const container = new Container<{ name: string }>();
+        // body() with no arg selects the root, so the chain operates on the
+        // string value validup mounted at 'name'.
+        container.mount('name', createValidator(() => body().trim()));
+
+        const outcome = await container.run({ name: '  Peter  ' });
+        expect(outcome.name).toEqual('Peter');
+    });
+});

--- a/packages/validup/src/container/module.ts
+++ b/packages/validup/src/container/module.ts
@@ -406,6 +406,12 @@ export class Container<
             (group) => Promise.allSettled(group.tasks.map((t) => t.promise)),
         ));
 
+        // Re-check the abort signal after settling. Sequential `run`/`runSync`
+        // probe between every mount; the parallel variant can only check here
+        // and before `finalizeOutput`. Without this, validators that ignore
+        // `ctx.signal` would let an aborted run resolve to a successful result.
+        options.signal?.throwIfAborted();
+
         let itemCount = 0;
         let errorCount = 0;
 
@@ -450,6 +456,11 @@ export class Container<
                 }
             }
         }
+
+        // Final guard before returning a (potentially successful) value — if
+        // the run was aborted after the post-settle check but before the merge
+        // loop finished, propagate the abort instead of returning stale data.
+        options.signal?.throwIfAborted();
 
         return this.finalizeOutput(output, options, issues, errorCount, itemCount);
     }
@@ -632,6 +643,28 @@ export class Container<
     }
 
     /**
+     * Prepend `keyParts` to a child issue's `path` and — when the child is
+     * an `IssueGroup` — recurse into its nested issues so every leaf carries
+     * the parent prefix. Without recursion, a child container that already
+     * wrapped its own multi-issue mount in a group (or a `oneOf` child) would
+     * surface inner items with paths missing the parent segment, breaking
+     * downstream consumers that rely on `flattenIssueItems` for per-field
+     * lookup (e.g. `@validup/vue`).
+     */
+    private prefixIssuePath(issue: Issue, keyParts: PropertyKey[]): Issue {
+        const prefixed: Issue = {
+            ...issue,
+            path: [...keyParts, ...(issue.path || [])],
+        };
+        if (prefixed.type === 'group') {
+            prefixed.issues = prefixed.issues.map(
+                (nested) => this.prefixIssuePath(nested, keyParts),
+            );
+        }
+        return prefixed;
+    }
+
+    /**
      * Translate a per-mount throw into accumulated `issues`. Re-throws when
      * the run was aborted (signal-aware validators) so abort errors are not
      * mangled into validation issues. `keyParts` is the current mount's
@@ -659,15 +692,7 @@ export class Container<
 
         if (isValidupError(e)) {
             for (let i = 0; i < e.issues.length; i++) {
-                const issue = e.issues[i];
-
-                childIssues.push({
-                    ...issue,
-                    path: [
-                        ...keyParts,
-                        ...(issue.path || []),
-                    ],
-                });
+                childIssues.push(this.prefixIssuePath(e.issues[i], keyParts));
             }
         } else if (isError(e)) {
             childIssues.push(defineIssueItem({
@@ -704,7 +729,11 @@ export class Container<
         itemCount: number,
     ): T {
         if (this.options.oneOf) {
-            if (errorCount === itemCount) {
+            // Guard against the "all branches filtered out" case (group /
+            // pathsToInclude / pathsToExclude can leave itemCount === 0).
+            // Without it, a oneOf container with nothing to run would throw
+            // ONE_OF_FAILED with an empty issues list.
+            if (itemCount > 0 && errorCount === itemCount) {
                 const group = defineIssueGroup({
                     code: IssueCode.ONE_OF_FAILED,
                     message: 'None of the branches succeeded',

--- a/packages/validup/test/unit/error.spec.ts
+++ b/packages/validup/test/unit/error.spec.ts
@@ -6,7 +6,15 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ValidupError, defineIssueGroup, isValidupError } from '../../src';
+import type { Validator } from '../../src';
+import {
+    Container,
+    IssueCode,
+    ValidupError,
+    defineIssueGroup,
+    flattenIssueItems,
+    isValidupError,
+} from '../../src';
 
 describe('error', () => {
     it('should verify error', () => {
@@ -54,5 +62,86 @@ describe('error', () => {
         expect(serialized.code).toEqual('VALIDUP_ERROR');
         expect(serialized.issues).toHaveLength(1);
         expect(serialized.issues[0]).toMatchObject({ type: 'group', message: 'foo' });
+    });
+
+    it('should recursively prefix nested IssueGroup paths from a child container', async () => {
+        // Regression: recordMountError prepended `keyParts` to each top-level
+        // child issue's path, but did not recurse into IssueGroup.issues. So
+        // when a child container's failure was already wrapped in an IssueGroup
+        // (e.g. by its own multi-issue mount aggregation, or a `oneOf` child),
+        // the inner IssueItems kept only the child-local key — making
+        // `flattenIssueItems` return leaves missing the parent prefix.
+        const failing: Validator = async () => {
+            throw new Error('bad');
+        };
+
+        // Child container holds a single mount whose path expands to two keys,
+        // so recordMountError wraps the two IssueItems in an IssueGroup at the
+        // child level. When the parent catches the child's ValidupError, the
+        // group's path AND its children's paths must both pick up the parent
+        // prefix.
+        const child = new Container<{ foo: string, bar: string }>();
+        child.mount('foo', failing);
+        child.mount('bar', failing);
+
+        const grandChild = new Container({ oneOf: true });
+        grandChild.mount('a', failing);
+        grandChild.mount('b', failing);
+        child.mount('one-of', grandChild);
+
+        const parent = new Container<{ nested: Record<string, unknown> }>();
+        parent.mount('nested', child);
+
+        expect.assertions(2);
+        try {
+            await parent.run({
+                nested: {
+                    foo: 1, 
+                    bar: 1, 
+                    'one-of': {}, 
+                }, 
+            });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                const items = flattenIssueItems(e.issues);
+                // Every leaf path must start with 'nested' — none kept the
+                // child-local key only.
+                expect(items.every((i) => i.path[0] === 'nested')).toBe(true);
+
+                // The oneOf grand-child surfaces as nested → one-of → a/b.
+                const oneOfLeafs = items.filter((i) => i.path[1] === 'one-of');
+                expect(
+                    oneOfLeafs.some((i) => i.path.join('.') === 'nested.one-of.a') &&
+                    oneOfLeafs.some((i) => i.path.join('.') === 'nested.one-of.b'),
+                ).toBe(true);
+            }
+        }
+    });
+
+    it('should re-path the ONE_OF_FAILED group itself when bubbling from a child', async () => {
+        const failing: Validator = async () => {
+            throw new Error('bad');
+        };
+        const child = new Container({ oneOf: true });
+        child.mount('a', failing);
+        child.mount('b', failing);
+
+        const parent = new Container<{ nested: Record<string, unknown> }>();
+        parent.mount('nested', child);
+
+        expect.assertions(3);
+        try {
+            await parent.run({ nested: {} });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                // Find the inner group with the ONE_OF_FAILED code, regardless
+                // of how recordMountError chose to wrap it.
+                const items = flattenIssueItems(e.issues);
+                expect(items.length).toBeGreaterThanOrEqual(2);
+                const codes = items.map((i) => i.code);
+                expect(codes.every((c) => c === IssueCode.VALUE_INVALID)).toBe(true);
+                expect(items.every((i) => i.path[0] === 'nested')).toBe(true);
+            }
+        }
     });
 });

--- a/packages/validup/test/unit/one-of.spec.ts
+++ b/packages/validup/test/unit/one-of.spec.ts
@@ -58,4 +58,30 @@ describe('oneOf', () => {
             }
         }
     });
+
+    it('should not throw when every branch is filtered out by group', async () => {
+        // Regression: oneOf compared errorCount === itemCount unconditionally,
+        // so a container whose branches were all filtered out (itemCount === 0)
+        // threw ONE_OF_FAILED with an empty issues list.
+        const container = new Container<{ foo: string, bar: string }>({ oneOf: true });
+        container.mount('foo', { group: 'create' }, stringValidator);
+        container.mount('bar', { group: 'create' }, stringValidator);
+
+        const output = await container.run({ foo: 'boz', bar: 'baz' }, { group: 'update' });
+
+        expect(output).toEqual({});
+    });
+
+    it('should not throw when every branch is filtered out by pathsToInclude', async () => {
+        const container = new Container<{ foo: string, bar: string }>({ oneOf: true });
+        container.mount('foo', stringValidator);
+        container.mount('bar', stringValidator);
+
+        const output = await container.run(
+            { foo: 'boz', bar: 'baz' },
+            { pathsToInclude: ['qux'] },
+        );
+
+        expect(output).toEqual({});
+    });
 });

--- a/packages/validup/test/unit/parallel.spec.ts
+++ b/packages/validup/test/unit/parallel.spec.ts
@@ -166,6 +166,36 @@ describe('Container.run parallel mode', () => {
         expect(out.b).toEqual('good');
     });
 
+    it('should honor abort even when validators ignore ctx.signal', async () => {
+        // Regression: runParallel only checked the signal at the gate before
+        // kicking off promises and via recordMountError on rejected tasks. A
+        // validator that ignored `ctx.signal` would let an aborted run resolve
+        // to a successful result. The fix adds explicit `throwIfAborted()`
+        // checks after `Promise.all` settles and before `finalizeOutput`.
+        const controller = new AbortController();
+        const signalDeaf: Validator = async (ctx) => {
+            // Abort lands while the validator is asleep — and the validator
+            // never observes ctx.signal. Mid-flight abort must still surface.
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, 20);
+            });
+            return ctx.value;
+        };
+
+        const container = new Container<{ a: string, b: string }>();
+        container.mount('a', signalDeaf);
+        container.mount('b', signalDeaf);
+
+        setTimeout(() => controller.abort(), 5);
+
+        try {
+            await container.run({ a: 1, b: 1 }, { parallel: true, signal: controller.signal });
+            expect.fail('expected abort');
+        } catch (e) {
+            expect((e as Error).name).toEqual('AbortError');
+        }
+    });
+
     it('should still honor group filtering in parallel mode', async () => {
         const seen: string[] = [];
         const tag = (name: string): Validator => async (ctx) => {

--- a/packages/vue/src/module.ts
+++ b/packages/vue/src/module.ts
@@ -389,13 +389,21 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral, C = unknown>
         }
         return cached;
     }
-    function liveStateKeys(): string[] {
-        // Reads `stateRef.value` (not `toRaw`) so reactive effects that walk
-        // `Object.keys(fields)` re-run when the underlying state object's
-        // shape changes — adding/removing top-level keys is rare in form
-        // state but does happen with conditional sub-forms.
+
+    // Reactive-tracking helper for `Object.keys` / `key in fields` access.
+    // Routing the lookup through a `computed` guarantees Vue tracks the
+    // dependency on `stateRef` (and its reactive proxy's `ownKeys`) regardless
+    // of whether the consumer's effect walks the proxy via `has`, `ownKeys`,
+    // or `getOwnPropertyDescriptor`. Without this, code like
+    //   computed(() => Object.keys(v.fields))
+    // would not re-evaluate when state keys appeared or disappeared, breaking
+    // the documented "conditional sub-forms" use case.
+    const liveStateKeysRef = computed<string[]>(() => {
         const data = stateRef.value as Record<string, unknown> | null | undefined;
         return data && typeof data === 'object' ? Object.keys(data) : [];
+    });
+    function liveStateKeys(): string[] {
+        return liveStateKeysRef.value;
     }
 
     const fields = new Proxy({} as ValidupComposable<T>['fields'], {

--- a/packages/vue/test/unit/robustness.spec.ts
+++ b/packages/vue/test/unit/robustness.spec.ts
@@ -300,3 +300,49 @@ describe('$crossCuttingErrors surfaces internal path-less issues (F4)', () => {
         expect($v.$crossCuttingErrors.value[0]?.meta?.external).toBeUndefined();
     });
 });
+
+describe('Object.keys(fields) is reactive to state-shape changes', () => {
+    const noop: Validator = (ctx) => ctx.value;
+
+    it('re-runs a computed when a top-level state key is added or removed', async () => {
+        // Regression: the Proxy's `ownKeys`/`has`/`getOwnPropertyDescriptor`
+        // traps read `stateRef.value` directly inside each call, but consumers
+        // walking `Object.keys($v.fields)` inside a `computed` depended on Vue
+        // tracking those traps as reactive accesses. The fix routes key
+        // discovery through a `computed` so the dependency is always set up.
+        const container = new Container<Record<string, unknown>>();
+        container.mount('a', noop);
+        container.mount('b', noop);
+
+        const state = reactive<Record<string, unknown>>({ a: 'x' });
+        const $v = useValidup(container, state);
+        await flush();
+
+        const observed: string[][] = [];
+
+        // Mount a component that owns the `computed` so reactivity is
+        // exercised in the same setup-context useValidup expects.
+        const Comp = defineComponent({
+            setup() {
+                return { keys: () => Object.keys($v.fields) };
+            },
+            render() {
+                observed.push(this.keys());
+                return h('div');
+            },
+        });
+        const wrapper = mount(Comp);
+
+        expect(observed.at(-1)).toEqual(['a']);
+
+        state.b = 'y';
+        await nextTick();
+        expect(observed.at(-1)).toEqual(['a', 'b']);
+
+        delete state.a;
+        await nextTick();
+        expect(observed.at(-1)).toEqual(['b']);
+
+        wrapper.unmount();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes seven correctness/stability findings surfaced by a careful audit of the changes accumulated since the last release. Without these, the open release-please PR #360 would ship the issues into the 0.3.x line.

### Core (`validup`)
- **`oneOf` empty-execution guard** — `finalizeOutput` now requires `itemCount > 0` before throwing `ONE_OF_FAILED`. Previously a `oneOf` container with every branch filtered out (`group` / `pathsToInclude` / `pathsToExclude`) threw with an empty `issues` list.
- **`runParallel` abort propagation** — `signal.throwIfAborted()` re-checked after `Promise.all` settles and before `finalizeOutput`, so a validator that ignores `ctx.signal` can no longer let an aborted run resolve to a successful result.
- **Recursive nested-IssueGroup re-pathing** — `recordMountError` now walks into `IssueGroup.issues` when prepending parent `keyParts`. Without it, a `oneOf` (or any multi-issue) child container surfaced inner leaves missing the parent prefix — silently breaking `flattenIssueItems`-based consumers like `@validup/vue`.

### `@validup/express-validator`
- **All chain errors translated, not just the first field's** — the previous implementation read `const [field] = getData()` and matched errors against that single field, silently dropping every other error.
- **`alternative` / `alternative_grouped` errors surfaced as `IssueGroup`** with `code: ONE_OF_FAILED`. They were previously filtered out by the `error.type === 'field'` guard. `alternative_grouped` preserves the per-branch structure as nested sub-groups.
- **Dotted/bracketed paths split into `PropertyKey[]`** — `"address.city"` → `["address","city"]`, `"items[0].name"` → `["items", 0, "name"]` — matching validup's `Issue.path` contract and enabling per-field lookup in `@validup/vue` for nested mounts.
- `unknown_fields` errors surface as a root-level issue instead of being swallowed.
- Dropped the now-unused `smob` runtime dependency.

### `@validup/vue`
- **`fields` Proxy key iteration now reactive** — `liveStateKeys()` routed through a `computed` so Vue tracks the dependency on `stateRef` regardless of which Proxy trap the consumer's effect uses. `computed(() => Object.keys(v.fields))` now re-evaluates when top-level state keys appear or disappear (the documented "conditional sub-forms" use case).

## Verification

- 3 separate commits (one per package) so release-please bucketed the changelogs correctly.
- Added 5 regression specs covering every fix:
  - `validup/test/unit/one-of.spec.ts` — all-branches-filtered case
  - `validup/test/unit/parallel.spec.ts` — abort with signal-deaf validators
  - `validup/test/unit/error.spec.ts` — nested `IssueGroup` (incl. `oneOf` grand-child) path prefix
  - `express-validator/test/unit/error.spec.ts` (new file) — path splitting, multi-field, `oneOf` group, sanitizer pass-through
  - `vue/test/unit/robustness.spec.ts` — `Object.keys($v.fields)` reacts to state-shape changes

## Test plan

- [x] `npm run build` — all 6 projects clean
- [x] `npm run lint` — no errors
- [x] `npm run test --skip-nx-cache` — 192 tests across 5 packages (validup 109, vue 59, express-validator 10, zod 8, standard-schema 6) all green
- [ ] Merge → release-please regenerates PR #360 with these fixes included → tag 0.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed reactive state shape tracking in Vue plugin when properties are added or removed.
  * Improved handling of nested validation error paths in container operations.
  * Enhanced abort signal handling during parallel validation operations.

* **Tests**
  * Added coverage for reactive property enumeration in Vue.
  * Added coverage for alternative validation failure scenarios.
  * Added coverage for abort signal behavior in parallel execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/validup/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->