### PR TITLE
Pre-1.0 audit fixes: oneOf grouping, mount validation, fallback issues, zod 3 drop, stability docs

### DIFF
--- a/packages/express-validator/README.md
+++ b/packages/express-validator/README.md
@@ -22,6 +22,7 @@ Wrap any express-validator `ValidationChain` as a validup `Validator`, mount it 
 - [Per-Context Chains](#per-context-chains)
 - [Error Mapping](#error-mapping)
 - [API Reference](#api-reference)
+- [Stability](#stability)
 - [License](#license)
 
 ## Installation
@@ -160,6 +161,24 @@ function createValidator<C = unknown>(
 
 function createValidationChain(): ValidationChain;
 ```
+
+## Stability
+
+What's covered by semver:
+
+- **Public exports** — `createValidator`, `createValidationChain`, and `buildIssuesForErrors`.
+- **Error-mapping shape** — all three express-validator error types (`field`, `alternative`, `alternative_grouped`) are mapped:
+  - `field` → flat `IssueItem` with the failing field name parsed into `path: PropertyKey[]` (numeric bracket indices become numbers).
+  - `alternative` and `alternative_grouped` → `IssueGroup` with `code: IssueCode.ONE_OF_FAILED`.
+  - `unknown_fields` → path-less `IssueItem` carrying the message.
+- **Return-value contract** — when the chain selects a single field and no errors are reported, the **sanitized** field value is returned; otherwise the original `ctx.value` passes through. This shape-shift is intentional so chains like `.toInt().trim()` carry through to the validup output. Callers that need the original value regardless can read `ctx.value` from outside the validator.
+- **Per-context chain factory** — `(ctx: ValidatorContext<C>) => ContextRunner` invocation contract.
+
+Peer dependency policy:
+
+- `express-validator ^7.3.1`.
+
+Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 
 ## License
 

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -16,6 +16,7 @@ Mount any Standard Schema as a validup `Validator` on a `Container` path; validu
 - [Error Mapping](#error-mapping)
 - [Choosing Between `@validup/zod` and `@validup/standard-schema`](#choosing-between-validupzod-and-validupstandard-schema)
 - [API Reference](#api-reference)
+- [Stability](#stability)
 - [License](#license)
 
 ## Installation
@@ -93,9 +94,8 @@ The adapter then throws a `ValidupError` with those issues; validup's container 
 | Vendor-portable adapter — swap libraries without touching mounts | `@validup/standard-schema` |
 | Surface zod's `expected` / `received` on issues       | `@validup/zod`             |
 | Bidirectional `validup ↔ zod` issue conversion        | `@validup/zod`             |
-| zod 3.x (< 3.24, no Standard Schema support)          | `@validup/zod`             |
 
-Both packages can coexist in the same project.
+Both packages can coexist in the same project. (`@validup/zod` requires `zod ^4.0.0` since 1.0; for zod 3.24+ via Standard Schema, use this package.)
 
 ## API Reference
 
@@ -108,6 +108,20 @@ function buildIssuesForStandardSchemaIssues(
     issues: ReadonlyArray<StandardSchemaV1.Issue>,
 ): Issue[];
 ```
+
+## Stability
+
+What's covered by semver:
+
+- **Public exports** — `createValidator` and `buildIssuesForStandardSchemaIssues`.
+- **Spec-portable issue mapping** — `message` and `path` are carried verbatim; `code` defaults to `IssueCode.VALUE_INVALID`. Vendor-specific fields are **not** part of the spec and never surface here.
+- **Per-context schema factory** — `(ctx: ValidatorContext<C>) => StandardSchemaV1` invocation contract.
+
+If you need vendor-specific fields like zod's `expected` / `received`, use [`@validup/zod`](https://npmjs.com/package/@validup/zod) instead — both packages can coexist.
+
+Peer dependency policy: no runtime peer deps. The adapter operates against the `@standard-schema/spec` types only and works against any spec-compatible schema instance (zod 3.24+, valibot, arktype, effect-schema, …).
+
+Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 
 ## License
 

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -49,6 +49,7 @@ Mount any validator function (or nested container) onto any path of your input, 
   - [Issue Helpers](#issue-helpers)
   - [Type Guards](#type-guards)
 - [Integrations](#integrations)
+- [Stability](#stability)
 - [License](#license)
 
 ## Installation
@@ -395,7 +396,7 @@ await container.run({ name: '', count: 0 });  // ✅ name skipped, count validat
 
 ## oneOf Branches
 
-A container created with `{ oneOf: true }` succeeds if **any one** of its mounts succeeds. Failures are aggregated into a single `IssueGroup` only when **all** branches fail.
+A container created with `{ oneOf: true }` succeeds if **any one** of its mounts succeeds. Failures are aggregated into a single `IssueGroup` (code `one_of_failed`) only when **all** branches fail, and each branch's contribution is wrapped in its own sub-group so consumers can recover per-branch identity.
 
 ```typescript
 const credential = new Container({ oneOf: true });
@@ -407,8 +408,19 @@ await credential.run({ email: 'peter@example.com' });
 // → { email: 'peter@example.com' } — username branch failure is ignored
 
 await credential.run({ email: 'not-an-email', username: 'invalid' });
-// → throws ValidupError with one IssueGroup (code: 'one_of_failed')
+// → throws ValidupError. error.issues is shaped:
+// [
+//   {
+//     type: 'group', code: 'one_of_failed', path: [],
+//     issues: [
+//       { type: 'group', path: [], params: { branch: 0, name: 'email' },    issues: [...] },
+//       { type: 'group', path: [], params: { branch: 1, name: 'username' }, issues: [...] },
+//     ],
+//   },
+// ]
 ```
+
+The per-branch sub-group's `params.branch` is the mount index (in registration order) and `params.name` is the mount path. Use `flattenIssueItems(error.issues)` for a flat list of leaf failures regardless of branch, or walk the sub-groups when you need to report which branch failed and why.
 
 ## Path Filtering
 
@@ -716,6 +728,30 @@ Use one of the official integration packages to bridge an existing validator lib
 | [`@validup/zod`](https://npmjs.com/package/@validup/zod)                             | [zod](https://zod.dev) schemas (vendor-specific issue mapping with `expected` / `received`) |
 | [`@validup/express-validator`](https://npmjs.com/package/@validup/express-validator) | [express-validator](https://express-validator.github.io) chains                |
 | [`@validup/vue`](https://npmjs.com/package/@validup/vue)                             | [Vue 3](https://vuejs.org) composable for reactive client-side form state      |
+
+## Stability
+
+What's covered by semver:
+
+- **Public exports** — everything re-exported from `validup`'s entry barrel (`Container`, `defineSchema`, `ValidupError`, `Issue` / factories / guards, `IssueCode`, `GroupKey`, `OptionalValue`, helpers in `formatIssue` / `flattenIssue*`).
+- **`Container` runtime contract** — `run` / `runSync` / `runParallel` (via `parallel: true`) / `safeRun` / `safeRunSync`, including their throw-contracts as documented on `IContainer` (`safeRun` throws only on abort).
+- **`Issue` and `ValidupError` shape** — the discriminated union (`type: 'item' | 'group'`), `params`, `meta`, `code` widening to `IssueCode | (string & {})`.
+- **Mount API** — variadic `mount(...)` argument forms listed in [Mounting](#mounting).
+- **`onefOf` aggregation shape** — `IssueCode.ONE_OF_FAILED` group wrapping per-branch sub-groups (see [oneOf Branches](#oneof-branches)).
+
+Extension points:
+
+- **`IssueCodeRegistry`** — declaration-merge in third-party packages to add typed codes (see [Issue Codes](#issue-codes)).
+- **`Validator<C, Out>`** — `C` (context) and `Out` (return type) generics participate in builder inference; defaults stay `unknown`.
+- **`IContainer`** — opt-in interface; integration packages can implement it to be mountable as a nested container.
+- **`isContainer` / `isValidupError`** — duck-typed guards that tolerate package duplicates and cross-realm throws. Prefer these over `instanceof` at boundaries.
+
+Internal (no semver guarantee):
+
+- Anything not re-exported from `src/index.ts`, including private helpers (`recordMountError`, `finalizeOutput`, etc.) and the `RunSyncViolationError` class.
+- Default English `Issue.message` strings — re-render via `formatIssue` and a `code → template` map if you depend on specific wording.
+
+Deprecation policy: a removal lands in at least one minor release as a deprecation (JSDoc `@deprecated` + console warning where feasible) before the next major drops it.
 
 ## License
 

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -737,7 +737,7 @@ What's covered by semver:
 - **`Container` runtime contract** — `run` / `runSync` / `runParallel` (via `parallel: true`) / `safeRun` / `safeRunSync`, including their throw-contracts as documented on `IContainer` (`safeRun` throws only on abort).
 - **`Issue` and `ValidupError` shape** — the discriminated union (`type: 'item' | 'group'`), `params`, `meta`, `code` widening to `IssueCode | (string & {})`.
 - **Mount API** — variadic `mount(...)` argument forms listed in [Mounting](#mounting).
-- **`onefOf` aggregation shape** — `IssueCode.ONE_OF_FAILED` group wrapping per-branch sub-groups (see [oneOf Branches](#oneof-branches)).
+- **`oneOf` aggregation shape** — `IssueCode.ONE_OF_FAILED` group wrapping per-branch sub-groups (see [oneOf Branches](#oneof-branches)).
 
 Extension points:
 

--- a/packages/validup/src/constants.ts
+++ b/packages/validup/src/constants.ts
@@ -11,15 +11,22 @@ export enum GroupKey {
 
 export enum OptionalValue {
     /**
-     * value: undefined
+     * Treats only `undefined` as optional. Default.
      */
     UNDEFINED = 'undefined',
     /**
-     * value: null & undefined
+     * Treats `null` and `undefined` as optional.
      */
     NULL = 'null',
     /**
-     * value: empty string, false, 0
+     * Treats any JS falsy value as optional — `undefined`, `null`, `false`,
+     * `0`, `''`, `NaN`.
+     *
+     * **Warning**: this includes `0` and `''`. For quantity / numeric fields
+     * where `0` is a meaningful value, prefer the predicate form
+     * `optional: (value) => boolean` so you keep control over what counts as
+     * missing (e.g. `optional: (v) => v === '' || v === undefined` drops the
+     * empty string but keeps `0`).
      */
     FALSY = 'falsy',
 }

--- a/packages/validup/src/container/module.ts
+++ b/packages/validup/src/container/module.ts
@@ -314,6 +314,12 @@ export class Container<
 
         type ItemGroup = {
             item: Mount<C>,
+            // Original registration index in `this.items`. Tracked separately
+            // from the position in `itemGroups` because group-filtered mounts
+            // are dropped from `itemGroups` — without this, `params.branch`
+            // emitted by `wrapBranchForOneOf` would not match the
+            // registration order seen by the consumer.
+            mountIndex: number,
             tasks: KeyTask[],
             // optional/skip paths that completed inline still count toward
             // the per-item pathCount used for oneOf / errorCount tracking.
@@ -417,9 +423,10 @@ export class Container<
 
             if (tasks.length > 0 || syncPathCount > 0) {
                 itemGroups.push({
-                    item, 
-                    tasks, 
-                    syncPathCount, 
+                    item,
+                    mountIndex: i,
+                    tasks,
+                    syncPathCount,
                 });
             }
         }
@@ -441,6 +448,7 @@ export class Container<
 
         for (const [i, {
             item,
+            mountIndex,
             tasks,
             syncPathCount,
         }] of itemGroups.entries()) {
@@ -478,7 +486,11 @@ export class Container<
                 itemCount++;
                 if (pathFailed) {
                     errorCount++;
-                    this.wrapBranchForOneOf(issues, branchStart, item, i);
+                    // Use the original registration index so `params.branch`
+                    // matches the registration order regardless of group
+                    // filtering — sequential `run()` / `runSync()` already
+                    // pass the registration index directly.
+                    this.wrapBranchForOneOf(issues, branchStart, item, mountIndex);
                 }
             }
         }

--- a/packages/validup/src/container/module.ts
+++ b/packages/validup/src/container/module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
@@ -76,32 +76,54 @@ export class Container<
         if (args.length < 1) {
             throw new SyntaxError('The mount method requires at least one argument');
         }
+        if (args.length > 3) {
+            throw new SyntaxError(`mount() accepts at most 3 arguments, got ${args.length}`);
+        }
 
         let path : string | undefined;
+        let pathSeen = false;
 
         let data: IContainer<any, any> | Validator<C> | undefined;
+        let dataSeen = false;
         let dataIsContainer : boolean = false;
 
         let options: MountOptions = {};
+        let optionsSeen = false;
 
         for (const arg of args) {
             if (typeof arg === 'string') {
+                if (pathSeen) {
+                    throw new SyntaxError('mount() received multiple string arguments — only one path is supported.');
+                }
+                pathSeen = true;
                 path = arg;
                 continue;
             }
 
             if (typeof arg === 'function') {
+                if (dataSeen) {
+                    throw new SyntaxError('mount() received multiple validator/container arguments.');
+                }
+                dataSeen = true;
                 data = arg;
                 continue;
             }
 
             if (isContainer(arg)) {
+                if (dataSeen) {
+                    throw new SyntaxError('mount() received multiple validator/container arguments.');
+                }
+                dataSeen = true;
                 data = arg;
                 dataIsContainer = true;
                 continue;
             }
 
             if (isObject(arg)) {
+                if (optionsSeen) {
+                    throw new SyntaxError('mount() received multiple options objects.');
+                }
+                optionsSeen = true;
                 options = arg;
             }
         }
@@ -174,6 +196,7 @@ export class Container<
 
             let pathCount = 0;
             let pathFailed = false;
+            const branchStart = issues.length;
 
             const keys: string[] = item.path ? expandPath(data, item.path) : [''];
 
@@ -259,6 +282,7 @@ export class Container<
 
                 if (pathFailed) {
                     errorCount++;
+                    this.wrapBranchForOneOf(issues, branchStart, item, i);
                 }
             }
         }
@@ -416,13 +440,14 @@ export class Container<
         let errorCount = 0;
 
         for (const [i, {
-            item, 
-            tasks, 
-            syncPathCount, 
+            item,
+            tasks,
+            syncPathCount,
         }] of itemGroups.entries()) {
             const settled = settledByGroup[i];
 
             let pathFailed = false;
+            const branchStart = issues.length;
             for (const [j, task] of tasks.entries()) {
                 const result = settled[j];
 
@@ -453,6 +478,7 @@ export class Container<
                 itemCount++;
                 if (pathFailed) {
                     errorCount++;
+                    this.wrapBranchForOneOf(issues, branchStart, item, i);
                 }
             }
         }
@@ -506,6 +532,7 @@ export class Container<
 
             let pathCount = 0;
             let pathFailed = false;
+            const branchStart = issues.length;
 
             const keys: string[] = item.path ? expandPath(data, item.path) : [''];
 
@@ -605,6 +632,7 @@ export class Container<
 
                 if (pathFailed) {
                     errorCount++;
+                    this.wrapBranchForOneOf(issues, branchStart, item, i);
                 }
             }
         }
@@ -699,6 +727,17 @@ export class Container<
                 path: keyParts,
                 message: e.message,
             }));
+        } else {
+            // Non-`Error` throw (string, plain object, null, …). Without a
+            // synthetic issue here, the run would still flag the mount as
+            // failed but the resulting `ValidupError.issues` would not
+            // mention the throw at all — caller sees "validation failed"
+            // with no diagnostic. Surface the stringified value so the
+            // failure is at least traceable.
+            childIssues.push(defineIssueItem({
+                path: keyParts,
+                message: typeof e === 'string' && e.length > 0 ? e : `Non-Error throw: ${String(e)}`,
+            }));
         }
 
         if (pathRelative) {
@@ -715,6 +754,43 @@ export class Container<
         } else {
             issues.push(...childIssues);
         }
+    }
+
+    /**
+     * For `oneOf` containers, wrap the issues produced by a single branch
+     * (slice from `branchStart` to the end of `issues`) into one sub-group
+     * so per-branch identity is preserved in the final aggregate. Non-oneOf
+     * containers leave the issue list untouched — they don't need branch
+     * partitioning.
+     *
+     * The wrapping group's `path` is `[]` (the branch wraps everything
+     * inside it; per-leaf paths are unchanged); `params.branch` is the
+     * mount index; and `params.name` (when set) is the mount path so
+     * consumers can label "branch X failed" without recomputing the
+     * registration order.
+     */
+    private wrapBranchForOneOf(
+        issues: Issue[],
+        branchStart: number,
+        item: Mount<C>,
+        branchIndex: number,
+    ): void {
+        if (!this.options.oneOf) {
+            return;
+        }
+        const branchIssues = issues.splice(branchStart);
+        const params: Record<string, unknown> = { branch: branchIndex };
+        if (item.path) {
+            params.name = item.path;
+        }
+        issues.push(defineIssueGroup({
+            message: item.path ?
+                `Branch "${item.path}" failed` :
+                `Branch ${branchIndex} failed`,
+            params,
+            path: [],
+            issues: branchIssues,
+        }));
     }
 
     /**
@@ -798,7 +874,20 @@ export class Container<
             };
         }
 
-        return { success: false, error: new ValidupError() };
+        // Non-`Error` throw (string, plain object, null, …). Surface a
+        // stringified diagnostic so `Result.error.issues` is never empty —
+        // an empty issue list with `success: false` is a confusing API
+        // signal ("validation failed" with no diagnostic) and is what
+        // landed in 0.x for non-Error throws.
+        return {
+            success: false,
+            error: new ValidupError([
+                defineIssueItem({
+                    path: [],
+                    message: typeof e === 'string' && e.length > 0 ? e : `Non-Error throw: ${String(e)}`,
+                }),
+            ]),
+        };
     }
 
     private isItemGroupIncluded(

--- a/packages/validup/src/container/types.ts
+++ b/packages/validup/src/container/types.ts
@@ -94,11 +94,17 @@ export type ContainerRunOptions<
      * resources (DB lookups, HTTP calls). Forwarded unchanged into nested
      * `run()` calls.
      *
-     * Trade-off: in parallel mode each mount captures its `value` from the
-     * input `data` *before* any other mount runs, so a later mount can no
-     * longer read an earlier mount's transformed `output[key]`. Use
-     * sequential mode (the default) for chained-key sanitize-then-validate
-     * patterns.
+     * **Trade-off — chained-key reads are not supported in parallel mode.**
+     * Sequential `run()` reads each mount's `value` from `output[key]` when
+     * an earlier sibling mount already wrote there (so a sanitizer at
+     * `email` followed by a validator at `email` sees the sanitized output).
+     * Parallel mode reads `value` from the input `data` for every mount
+     * because siblings may not have completed yet. If you rely on chained
+     * sanitize-then-validate patterns, stay on sequential mode (the
+     * default). The behavior is intentional and consistent between
+     * `run({parallel: true})` and `safeRun({parallel: true})` — there is
+     * no diagnostic when a chained pattern is used in parallel mode; the
+     * later mount silently observes the un-sanitized input.
      */
     parallel?: boolean
 };
@@ -153,10 +159,9 @@ export type Result<T extends ObjectLiteral = ObjectLiteral> = ResultSuccess<T> |
 
 export interface IContainer<T extends ObjectLiteral = ObjectLiteral, C = unknown> {
     /**
-     * Run container with given input.
-     *
-     * @param input
-     * @param options
+     * Run the container against `input`. Throws `ValidupError` on validation
+     * failure; rethrows `signal.reason` when the run is aborted via
+     * `options.signal`.
      */
     run(
         input?: Record<string, any>,
@@ -164,10 +169,17 @@ export interface IContainer<T extends ObjectLiteral = ObjectLiteral, C = unknown
     ): Promise<T>
 
     /**
-     * Safe run container with given input.
+     * Run the container against `input` and return a discriminated `Result`
+     * instead of throwing on validation failure.
      *
-     * @param input
-     * @param options
+     * **Contract — when `safeRun` can still throw:**
+     * - The run is aborted via `options.signal` — `signal.reason` is
+     *   re-thrown verbatim so callers can distinguish "validation failed"
+     *   from "operation cancelled."
+     * - This is the **only** sanctioned reason. Implementations that throw
+     *   for any other reason violate the contract; consumers that wrap
+     *   `safeRun` in a defensive `try/catch` (e.g. `@validup/vue`) treat
+     *   such throws as a synthetic path-less failure.
      */
     safeRun(
         input?: Record<string, any>,
@@ -179,6 +191,11 @@ export interface IContainer<T extends ObjectLiteral = ObjectLiteral, C = unknown
      * this when their validators are inherently async. The default
      * `Container` provides it; nested containers without it cannot be
      * traversed by a parent's `runSync`.
+     *
+     * Throws `RunSyncViolationError` (structural — distinct from validation
+     * failures) when any validator returns a thenable or any nested
+     * container lacks `runSync`. Those throws bypass the issue-folding path
+     * and surface verbatim.
      */
     runSync?(
         input?: Record<string, any>,
@@ -187,6 +204,10 @@ export interface IContainer<T extends ObjectLiteral = ObjectLiteral, C = unknown
 
     /**
      * Synchronous variant of `safeRun()`. Optional — same caveat as `runSync`.
+     *
+     * Same throw-contract as `safeRun`, plus: `RunSyncViolationError`s are
+     * re-thrown (not wrapped into `Result.failure`) because they signal a
+     * structural mismatch, not a validation outcome.
      */
     safeRunSync?(
         input?: Record<string, any>,

--- a/packages/validup/src/issue/constants.ts
+++ b/packages/validup/src/issue/constants.ts
@@ -7,12 +7,14 @@
 
 /**
  * Registry of well-known issue codes. Third-party packages can extend the
- * union via TypeScript declaration merging:
+ * union via TypeScript declaration merging. Keys are conventionally
+ * `UPPER_SNAKE_CASE` (matching the built-ins below); values are the runtime
+ * literal strings used on `IssueItem.code` (conventionally lowercase):
  *
  * ```ts
  * declare module 'validup' {
  *     interface IssueCodeRegistry {
- *         email_taken: 'email_taken';
+ *         EMAIL_TAKEN: 'email_taken';
  *     }
  * }
  * ```

--- a/packages/validup/test/unit/error.spec.ts
+++ b/packages/validup/test/unit/error.spec.ts
@@ -161,7 +161,7 @@ describe('error', () => {
         }
     });
 
-    it('should surface non-Error throws via safeRun as a path-less synthetic issue', async () => {
+    it('should record non-Error throws under the mounted path via safeRun', async () => {
         const stringThrowing: Validator = () => {
             // eslint-disable-next-line no-throw-literal
             throw 'safeRun caught me';
@@ -172,13 +172,15 @@ describe('error', () => {
         const result = await container.safeRun({ foo: 'x' });
         expect(result.success).toBe(false);
         if (!result.success) {
-            // Behavior: a non-Error throw inside a mount goes through the
-            // sequential `run()` path, which folds it via recordMountError —
-            // so it ends up under `['foo']`, not as a path-less synthetic
-            // (`wrapSafeRunError` is only reached for throws that bypass the
-            // mount catch, like a buggy IContainer breaking the contract).
+            // A non-Error throw inside a mount goes through the sequential
+            // `run()` path, which folds it via recordMountError — so it ends
+            // up attached to the mount's path (`['foo']`), not as a path-less
+            // synthetic. (`wrapSafeRunError`'s path-less synthesis is reserved
+            // for throws that bypass the mount catch entirely — e.g. a buggy
+            // `IContainer` implementation breaking `safeRun`'s contract.)
             const items = flattenIssueItems(result.error.issues);
-            expect(items.length).toBeGreaterThan(0);
+            expect(items).toHaveLength(1);
+            expect(items[0].path).toEqual(['foo']);
             expect(items[0].message).toEqual('safeRun caught me');
         }
     });

--- a/packages/validup/test/unit/error.spec.ts
+++ b/packages/validup/test/unit/error.spec.ts
@@ -118,6 +118,71 @@ describe('error', () => {
         }
     });
 
+    it('should synthesize a fallback IssueItem when a validator throws a string', async () => {
+        const stringThrowing: Validator = () => {
+            // eslint-disable-next-line no-throw-literal
+            throw 'pure string failure';
+        };
+        const container = new Container<{ foo: string }>();
+        container.mount('foo', stringThrowing);
+
+        expect.assertions(3);
+        try {
+            await container.run({ foo: 'x' });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                const items = flattenIssueItems(e.issues);
+                expect(items).toHaveLength(1);
+                expect(items[0].path).toEqual(['foo']);
+                expect(items[0].message).toEqual('pure string failure');
+            }
+        }
+    });
+
+    it('should synthesize a fallback IssueItem when a validator throws a non-Error object', async () => {
+        const objectThrowing: Validator = () => {
+            // eslint-disable-next-line no-throw-literal
+            throw { not: 'an error' };
+        };
+        const container = new Container<{ foo: string }>();
+        container.mount('foo', objectThrowing);
+
+        expect.assertions(2);
+        try {
+            await container.run({ foo: 'x' });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                const items = flattenIssueItems(e.issues);
+                expect(items).toHaveLength(1);
+                // Non-Error throws surface with a synthetic prefix so the
+                // diagnostic is at least traceable in logs.
+                expect(items[0].message.startsWith('Non-Error throw:')).toBe(true);
+            }
+        }
+    });
+
+    it('should surface non-Error throws via safeRun as a path-less synthetic issue', async () => {
+        const stringThrowing: Validator = () => {
+            // eslint-disable-next-line no-throw-literal
+            throw 'safeRun caught me';
+        };
+        const container = new Container<{ foo: string }>();
+        container.mount('foo', stringThrowing);
+
+        const result = await container.safeRun({ foo: 'x' });
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            // Behavior: a non-Error throw inside a mount goes through the
+            // sequential `run()` path, which folds it via recordMountError —
+            // so it ends up under `['foo']`, not as a path-less synthetic
+            // (`wrapSafeRunError` is only reached for throws that bypass the
+            // mount catch, like a buggy IContainer breaking the contract).
+            const items = flattenIssueItems(result.error.issues);
+            expect(items.length).toBeGreaterThan(0);
+            expect(items[0].message).toEqual('safeRun caught me');
+        }
+    });
+
     it('should re-path the ONE_OF_FAILED group itself when bubbling from a child', async () => {
         const failing: Validator = async () => {
             throw new Error('bad');

--- a/packages/validup/test/unit/mount-key.spec.ts
+++ b/packages/validup/test/unit/mount-key.spec.ts
@@ -166,9 +166,11 @@ describe('module/mount-key', () => {
 
     it('should reject mount() with multiple options objects', () => {
         const container = new Container();
-        const validator = (ctx: ValidatorContext) => ctx.value;
+        // Three args (path + two options objects) stays within the arity
+        // guard so the duplicate-options branch is the one that fires.
+        // Passing a fourth (validator) would trip the >3 args guard first.
         expect(
-            () => (container.mount as (...args: unknown[]) => void)('foo', { optional: true }, { group: 'a' }, validator),
-        ).toThrow(/at most 3 arguments/);
+            () => (container.mount as (...args: unknown[]) => void)('foo', { optional: true }, { group: 'a' }),
+        ).toThrow(/multiple options objects/);
     });
 });

--- a/packages/validup/test/unit/mount-key.spec.ts
+++ b/packages/validup/test/unit/mount-key.spec.ts
@@ -133,4 +133,42 @@ describe('module/mount-key', () => {
             value: 2,
         } satisfies Partial<ValidatorContext>);
     });
+
+    it('should reject mount() with no arguments', () => {
+        const container = new Container();
+        // @ts-expect-error — testing runtime validation, not type-level
+        expect(() => container.mount()).toThrow(SyntaxError);
+    });
+
+    it('should reject mount() with more than three arguments', () => {
+        const container = new Container();
+        const validator = (ctx: ValidatorContext) => ctx.value;
+        expect(
+            () => (container.mount as (...args: unknown[]) => void)('foo', { optional: true }, validator, 'extra'),
+        ).toThrow(/at most 3 arguments/);
+    });
+
+    it('should reject mount() with multiple string arguments', () => {
+        const container = new Container();
+        const validator = (ctx: ValidatorContext) => ctx.value;
+        expect(
+            () => (container.mount as (...args: unknown[]) => void)('foo', 'bar', validator),
+        ).toThrow(/multiple string arguments/);
+    });
+
+    it('should reject mount() with multiple validator/container arguments', () => {
+        const container = new Container();
+        const validator = (ctx: ValidatorContext) => ctx.value;
+        expect(
+            () => (container.mount as (...args: unknown[]) => void)('foo', validator, validator),
+        ).toThrow(/multiple validator\/container arguments/);
+    });
+
+    it('should reject mount() with multiple options objects', () => {
+        const container = new Container();
+        const validator = (ctx: ValidatorContext) => ctx.value;
+        expect(
+            () => (container.mount as (...args: unknown[]) => void)('foo', { optional: true }, { group: 'a' }, validator),
+        ).toThrow(/at most 3 arguments/);
+    });
 });

--- a/packages/validup/test/unit/one-of.spec.ts
+++ b/packages/validup/test/unit/one-of.spec.ts
@@ -1,12 +1,18 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
 import { describe, expect, it } from 'vitest';
-import { Container, ValidupError } from '../../src';
+import {
+    Container,
+    IssueCode,
+    ValidupError,
+    flattenIssueItems,
+    isIssueGroup,
+} from '../../src';
 import { stringValidator } from '../data';
 
 describe('oneOf', () => {
@@ -83,5 +89,38 @@ describe('oneOf', () => {
         );
 
         expect(output).toEqual({});
+    });
+
+    it('should wrap each failing branch in its own sub-group inside ONE_OF_FAILED', async () => {
+        const container = new Container<{ foo: string, bar: string }>({ oneOf: true });
+        container.mount('foo', stringValidator);
+        container.mount('bar', stringValidator);
+
+        expect.assertions(7);
+        try {
+            await container.run({ foo: 1, bar: 2 });
+        } catch (e) {
+            if (e instanceof ValidupError) {
+                expect(e.issues).toHaveLength(1);
+
+                const [outer] = e.issues;
+                expect(isIssueGroup(outer)).toBe(true);
+                if (!isIssueGroup(outer)) return;
+                expect(outer.code).toEqual(IssueCode.ONE_OF_FAILED);
+
+                // Two sub-groups, one per branch — per-branch identity preserved.
+                expect(outer.issues).toHaveLength(2);
+                expect(outer.issues.every(isIssueGroup)).toBe(true);
+
+                const branchNames = outer.issues
+                    .filter(isIssueGroup)
+                    .map((g) => g.params?.name);
+                expect(branchNames).toEqual(['foo', 'bar']);
+
+                // Leaves still flatten to the original two failures.
+                const items = flattenIssueItems(e.issues);
+                expect(items.map((i) => i.path.join('.')).sort()).toEqual(['bar', 'foo']);
+            }
+        }
     });
 });

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -44,10 +44,10 @@ Drive form validation from a validup `Container<T>` with a vuelidate-shaped comp
 npm install @validup/vue validup vue --save
 ```
 
-| Peer dependency | Supported versions |
+| Dependency      | Supported versions |
 |-----------------|--------------------|
-| `validup`       | `^1.0.0`           |
-| `vue`           | `^3.3`             |
+| `validup`       | `^0.3.0` (runtime `dependencies` entry, not peer — will move to peer + `^1.0.0` at the coordinated 1.0 cut) |
+| `vue`           | `^3.3` (peer)      |
 
 ## Quick Start
 
@@ -471,9 +471,11 @@ Internal (no semver guarantee):
 - The `Proxy`-backed `fields` accessor's exact dispatch (`getOwnPropertyDescriptor` returning a data descriptor with `value`, etc.) — observable behavior (per-field state, reactive key tracking) is stable; the underlying mechanism is not.
 - The run-id / abort token internals.
 
-Peer dependency policy:
+Dependency policy:
 
-- `validup ^1.0.0`, `vue ^3.3`, `@vueuse/core` (transitive).
+- `validup` — currently bundled as a runtime `dependencies` entry at `^0.3.0`. At the coordinated 1.0 cut this moves to `peerDependencies` at `^1.0.0` so consumers don't carry two copies of the core.
+- `vue` — peer dependency, `^3.3`.
+- `@vueuse/core` — transitive runtime dependency.
 
 Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -35,6 +35,7 @@ Drive form validation from a validup `Container<T>` with a vuelidate-shaped comp
 - [Severity](#severity)
 - [API Reference](#api-reference)
 - [Migrating from Vuelidate](#migrating-from-vuelidate)
+- [Stability](#stability)
 - [License](#license)
 
 ## Installation
@@ -45,7 +46,7 @@ npm install @validup/vue validup vue --save
 
 | Peer dependency | Supported versions |
 |-----------------|--------------------|
-| `validup`       | `^0.2.2`           |
+| `validup`       | `^1.0.0`           |
 | `vue`           | `^3.3`             |
 
 ## Quick Start
@@ -449,6 +450,32 @@ What changes substantively:
 - **Async timing** — `options.lazy` is the analog of Vuelidate's `$lazy: true`. By default, validation runs eagerly internally and per-field error rendering is gated on `$dirty`, so the visible UX matches Vuelidate's `$lazy: true`. Pass `lazy: true` to additionally skip the on-mount probe (useful for expensive async validators).
 - **`$autoDirty`** — set `options.autoDirty: true` when state is mutated outside of `$model` (e.g. via Pinia store actions). Default-off preserves silent hydration.
 - **`$scope`** — set `options.scope` on both parent and children to partition multiple aggregation roots (multi-step wizards, tab panels). Replaces Vuelidate's `$scope` config.
+
+## Stability
+
+What's covered by semver:
+
+- **Public exports** — `useValidup`, `getValidupSeverity`, `extractValidupResultsFromChild`, `PARENT_INJECTION_KEY`, and the `ValidupComposable` / `FieldState` / `ValidupComposableOptions` / `ValidupSeverity` types.
+- **`ValidupComposable<T>` shape** — every documented member in the [API Reference](#api-reference) table, including the `$crossCuttingErrors` / `$groupErrors` accessors and the `setExternalIssues` / `$validate` / `$getResultsForChild` methods.
+- **Options contract** — `group`, `context`, `debounce`, `name`, `stopPropagation`, `detached`, `lazy`, `autoDirty`, `scope`. New options will be additive within a major.
+- **Parent / child collector protocol** — `PARENT_INJECTION_KEY` and per-scope `Symbol.for('validup:parent:<scope>')` are the wire format. Third-party composables can `provide` / `inject` the same key to participate.
+- **Dirty / external-issue semantics** — `$model` writes flip dirty + auto-clear external issues at the same path; `$reset` clears dirty + external but leaves internal issues (which reflect current state); `setExternalIssues` tags entries with `meta.external = true`.
+
+Extension points:
+
+- **Custom aggregation roots** — `stopPropagation: true` (collect descendants, ignore ancestors) and `detached: true` (invisible in both directions) are the two blessed shapes.
+- **Buggy `IContainer` safety net** — a defensive `try/catch` around `safeRun` surfaces a path-less synthetic `IssueItem` (`code: VALUE_INVALID`) in `$crossCuttingErrors` rather than crashing the watcher.
+
+Internal (no semver guarantee):
+
+- The `Proxy`-backed `fields` accessor's exact dispatch (`getOwnPropertyDescriptor` returning a data descriptor with `value`, etc.) — observable behavior (per-field state, reactive key tracking) is stable; the underlying mechanism is not.
+- The run-id / abort token internals.
+
+Peer dependency policy:
+
+- `validup ^1.0.0`, `vue ^3.3`, `@vueuse/core` (transitive).
+
+Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 
 ## License
 

--- a/packages/vue/src/module.ts
+++ b/packages/vue/src/module.ts
@@ -29,7 +29,6 @@ import type {
 import {
     IssueCode,
     ValidupError,
-    flattenIssueGroups,
     flattenIssueItems,
     isIssueGroup,
     isValidupError,
@@ -538,7 +537,14 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral, C = unknown>
         ]).filter((i) => i.path.length === 0)),
         // Group-level issues (e.g. ONE_OF_FAILED). Empty-path groups surface
         // once any field is dirty; nested groups gate on prefix-dirty rules.
-        $groupErrors: computed(() => flattenIssueGroups([...internalIssues.value, ...externalIssues.value])
+        //
+        // Top-level groups only — `oneOf` containers wrap each failing branch
+        // in its own sub-group inside ONE_OF_FAILED to preserve per-branch
+        // identity (`params.branch` / `params.name`). Those sub-groups are
+        // not themselves `$groupErrors` targets; consumers that need the
+        // per-branch detail walk `$issues` instead.
+        $groupErrors: computed(() => [...internalIssues.value, ...externalIssues.value]
+            .filter(isIssueGroup)
             .filter((g) => {
                 if (g.path.length === 0) {
                     return dirtyPaths.size > 0;

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -169,7 +169,7 @@ function createValidator<C = unknown>(input: ZodType | ((ctx: ValidatorContext<C
 What's covered by semver:
 
 - **Public exports** — `createValidator`, `buildIssuesForZodError`, `buildZodIssuesForError`, `buildZodIssuesForIssue`, and the `ZodIssue` type alias.
-- **Error-mapping shape** — `IssueItem.path` mirrors the failing zod path; `IssueItem.expected` / `received` are populated when zod exposes them; vendor-specific zod fields (`code`, `params`, …) are intentionally not surfaced (use `@validup/zod`'s `buildZodIssuesForError` round-trip if you need the original zod data).
+- **Error-mapping shape** — `IssueItem.path` mirrors the failing zod path; `IssueItem.expected` / `received` are populated when zod exposes them. Other zod-only fields (`code`, `params`, …) are intentionally not surfaced. `buildZodIssuesForError` reconstructs a zod-shaped representation from a `ValidupError` (`code: 'custom'`, the message, the path, and the original `received` value as `input`) — it does **not** recover the dropped zod fields. If you need them end-to-end, keep the `ZodError` available alongside the `ValidupError`.
 - **Per-context schema factory** — `(ctx: ValidatorContext<C>) => ZodType` invocation contract.
 
 Known lossy behavior:

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -27,6 +27,7 @@ Wrap any zod schema as a validup `Validator`, mount it on a `Container` path, an
   - [Zod → Validup](#zod--validup)
   - [Validup → Zod](#validup--zod)
 - [API Reference](#api-reference)
+- [Stability](#stability)
 - [License](#license)
 
 ## Installation
@@ -37,7 +38,9 @@ npm install @validup/zod validup zod --save
 
 | Peer dependency | Supported versions  |
 |-----------------|---------------------|
-| `zod`           | `^3.25.0 \|\| ^4.0.0` |
+| `zod`           | `^4.0.0`            |
+
+> ℹ️ **zod 3 support was dropped in `@validup/zod@1.0`.** The adapter's `ZodIssue` type alias resolves to `zod/v4/core`'s `$ZodRawIssue`, which is not available in zod 3. Stay on `@validup/zod@<1` if you cannot upgrade zod; otherwise upgrade zod to `^4.0.0` alongside this package.
 
 ## Quick Start
 
@@ -145,6 +148,8 @@ try {
 }
 ```
 
+> ⚠️ **`IssueGroup` round-trip is lossy.** validup's `Issue` is a discriminated union of `IssueItem` and `IssueGroup`. zod has no group equivalent, so `buildZodIssuesForIssue` recursively flattens every `IssueGroup` into its constituent `IssueItem`s when emitting zod issues — group-level metadata (`code: 'one_of_failed'`, `params.name`, etc.) is dropped. The reverse direction (zod → validup) never produces groups, so a `zod ← validup` round-trip on a flat issue list is preserved; a round-trip that involves grouped errors is not.
+
 ## API Reference
 
 | Export                       | Description                                                                  |
@@ -158,6 +163,24 @@ try {
 ```typescript
 function createValidator<C = unknown>(input: ZodType | ((ctx: ValidatorContext<C>) => ZodType)): Validator<C>;
 ```
+
+## Stability
+
+What's covered by semver:
+
+- **Public exports** — `createValidator`, `buildIssuesForZodError`, `buildZodIssuesForError`, `buildZodIssuesForIssue`, and the `ZodIssue` type alias.
+- **Error-mapping shape** — `IssueItem.path` mirrors the failing zod path; `IssueItem.expected` / `received` are populated when zod exposes them; vendor-specific zod fields (`code`, `params`, …) are intentionally not surfaced (use `@validup/zod`'s `buildZodIssuesForError` round-trip if you need the original zod data).
+- **Per-context schema factory** — `(ctx: ValidatorContext<C>) => ZodType` invocation contract.
+
+Known lossy behavior:
+
+- `buildZodIssuesForIssue` flattens `IssueGroup`s when emitting zod issues (zod has no group concept) — group-level `code` and `params` are dropped.
+
+Peer dependency policy:
+
+- `zod ^4.0.0`. zod 3.x was dropped in `@validup/zod@1.0` because the adapter's `ZodIssue` type alias resolves to `zod/v4/core`, which is not available in zod 3.
+
+Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 
 ## License
 

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -43,7 +43,7 @@
         "zod": "^4.4.3"
     },
     "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
+        "zod": "^4.0.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
## Summary

Surgical fixes from the pre-1.0 audit of all five validup packages. Three branches of work:

1. **`feat(validup)!`** — `oneOf` containers now wrap each failing branch in its own sub-group inside `ONE_OF_FAILED` so consumers can recover per-branch identity; `recordMountError` / `wrapSafeRunError` synthesize fallback `IssueItem`s when a validator throws a non-`Error` value (previously produced a `ValidupError` with empty `issues`); `mount(...)` rejects ambiguous argument shapes (multiple paths, multiple validators, multiple options objects, >3 args); JSDoc tightened on `ContainerRunOptions.parallel`, `IContainer.safeRun*`, `OptionalValue.FALSY`, `IssueCodeRegistry`.
2. **`feat(zod)!`** — peer dep narrowed to `zod ^4.0.0`. The adapter's `ZodIssue` type alias resolved to `zod/v4/core` which never existed in zod 3, so the `^3.25.0 || ^4.0.0` peer range was broken at the type level. The runtime worked on both; the type-level claim did not.
3. **`docs`** — Stability section added to all five package READMEs (what's covered by semver, extension points, peer dep policy, deprecation policy); the `@validup/zod` README documents the lossy `IssueGroup` round-trip; the `@validup/standard-schema` picker no longer references the now-dropped zod 3 path.

Six audit findings (S1 run-matrix collapse, S7 `useValidup` decomposition, N1 standard-schema/zod consolidation, N2 `createValidationChain` disposition, N3 express-validator single-field unwrap, N4 `canRunSync` introspection) are deferred — each one is a design decision, not a mechanical fix. They are queued in `.agents/plans/1.0-followups.md` (local working doc — that directory is gitignored).

## Breaking changes

- **`@validup/zod`** drops zod 3 from `peerDependencies`. Migration: upgrade to `zod ^4.0.0`, or stay on `@validup/zod@<1`.
- **`validup`** — `oneOf` containers' `ValidupError.issues` gains one nesting level: each failing branch is wrapped in its own `IssueGroup` inside the `ONE_OF_FAILED` aggregate. `flattenIssueItems` output is unchanged. Consumers walking groups directly (`error.issues[0].issues.filter(isIssueItem)`) get the same items, just nested one level deeper.

## Test plan

- [x] `npm run test` — 192 tests pass (109 in `validup` core + 9 new in this PR + 74 across integration packages)
- [x] `npm run lint` — clean
- [x] `npm run build` — all five packages + docs site build clean
- [ ] Manual smoke against a downstream consumer (validup is currently used only in @tada5hi's own projects per the audit conversation, so this is essentially "does the next consumer-side migration work")

## Follow-ups (NOT in this PR)

Tracked in `.agents/plans/1.0-followups.md` — six items deferred for an alignment conversation before they can land. None blocks the 1.0 cut decision on the items that *did* land here; the deferred items shape future API surface that 1.0 then commits to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Stability”/semver guidance across packages and adapters; clarified deprecation and peer-dependency policies
  * Expanded oneOf aggregation and container execution semantics; clarified optional-value semantics and public contracts

* **Bug Fixes**
  * Improved synthesis of issues for non-Error throws
  * Stronger mount argument validation with clearer errors

* **Tests**
  * Added tests for non-Error throws, mount validation, and oneOf aggregation

* **Chores**
  * Zod adapter now requires Zod v4 only

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/validup/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->