### PR TITLE
docs(validup): run-modes reference table + tighten run/runSync JSDoc

### DIFF
--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -35,9 +35,10 @@ Mount any validator function (or nested container) onto any path of your input, 
 - [Defaults](#defaults)
 - [Context](#context)
 - [Cancellation](#cancellation)
-- [Parallel Execution](#parallel-execution)
-- [Safe Run](#safe-run)
-- [Sync Fast Path](#sync-fast-path)
+- [Run Modes](#run-modes)
+  - [Parallel Execution](#parallel-execution)
+  - [Safe Run](#safe-run)
+  - [Sync Fast Path](#sync-fast-path)
 - [Localized Messages](#localized-messages)
 - [Error Handling](#error-handling)
   - [ValidupError](#validuperror)
@@ -481,7 +482,26 @@ try {
 
 `safeRun()` rethrows the abort reason (it is never wrapped into a `Result.failure`) so callers can distinguish "validation failed" from "operation cancelled".
 
-## Parallel Execution
+## Run Modes
+
+Five methods cover three orthogonal axes — **sync vs async**, **throw vs no-throw `Result`**, and **sequential vs parallel** (async only):
+
+| Need                                              | Call                                          | Returns               |
+|---------------------------------------------------|-----------------------------------------------|-----------------------|
+| Async, throws on validation failure (default)     | `container.run(input, opts)`                  | `Promise<T>`          |
+| Async, throws, parallel mounts                    | `container.run(input, { parallel: true })`    | `Promise<T>`          |
+| Async, no-throw `Result`                          | `container.safeRun(input, opts)`              | `Promise<Result<T>>`  |
+| Async, no-throw, parallel mounts                  | `container.safeRun(input, { parallel: true })`| `Promise<Result<T>>`  |
+| Sync, throws on validation failure                | `container.runSync(input, opts)`              | `T`                   |
+| Sync, no-throw `Result`                           | `container.safeRunSync(input, opts)`          | `Result<T>`           |
+
+`sync + parallel` is intentionally not a combination — `Promise.allSettled` is async by definition, and sync graphs don't benefit from concurrency.
+
+**When `safe*` still throws:** the abort reason from `options.signal`, and the structural `RunSyncViolationError` from `safeRunSync` when a validator returns a Promise or a nested container doesn't implement `runSync`. Both bypass the issue-folding path so callers can distinguish them from validation outcomes.
+
+Details on each axis below.
+
+### Parallel Execution
 
 By default mounts run sequentially in registration order. For containers whose mounts hit independent slow async resources (multiple DB lookups, HTTP calls), opt into parallel mode:
 
@@ -493,7 +513,7 @@ All mounts kick off concurrently and the results merge in registration order —
 
 **Trade-off**: in parallel mode each mount captures its `value` from the input `data` *before* any sibling mount runs, so a later mount can no longer read an earlier mount's transformed `output[key]`. Stick with sequential mode (the default) for chained-key sanitize-then-validate patterns.
 
-## Safe Run
+### Safe Run
 
 `safeRun()` returns a discriminated `Result<T>` instead of throwing — handy when you want to deal with errors without `try/catch`:
 
@@ -507,7 +527,7 @@ if (result.success) {
 }
 ```
 
-## Sync Fast Path
+### Sync Fast Path
 
 When every mounted validator (and every nested container's `runSync`) is synchronous, use `runSync()` / `safeRunSync()` to skip the per-mount microtask overhead of `await`:
 

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -484,7 +484,7 @@ try {
 
 ## Run Modes
 
-Five methods cover three orthogonal axes — **sync vs async**, **throw vs no-throw `Result`**, and **sequential vs parallel** (async only):
+Four methods — `container.run` / `container.runSync` / `container.safeRun` / `container.safeRunSync` — plus a `parallel` flag on the async ones cover three orthogonal axes: **sync vs async**, **throw vs no-throw `Result`**, and **sequential vs parallel** (async only):
 
 | Need                                              | Call                                          | Returns               |
 |---------------------------------------------------|-----------------------------------------------|-----------------------|

--- a/packages/validup/src/container/module.ts
+++ b/packages/validup/src/container/module.ts
@@ -139,10 +139,26 @@ export class Container<
     // ----------------------------------------------
 
     /**
-     * @throws ValidupError
+     * Run the container against `data`. Default execution mode — async,
+     * sequential, throws `ValidupError` on validation failure.
      *
-     * @param data
-     * @param options
+     * Variants for the other execution modes:
+     * - `run(data, { parallel: true })` — async, sequential→concurrent. Each
+     *   mount captures `value` from `data` before any sibling runs, so chained
+     *   sanitize-then-validate patterns are not supported.
+     * - {@link Container.safeRun} — same as `run` but returns a discriminated
+     *   `Result<T>` instead of throwing on validation failure (still rethrows
+     *   on abort).
+     * - {@link Container.runSync} / {@link Container.safeRunSync} — synchronous
+     *   variants for graphs where every validator (and every nested container's
+     *   `runSync`) is synchronous.
+     *
+     * Rethrows `options.signal.reason` when the run is aborted — abort is
+     * surfaced as the signal's reason, not folded into the issue tree, so
+     * callers can distinguish "validation failed" from "operation cancelled".
+     *
+     * @throws ValidupError on validation failure.
+     * @throws signal.reason when aborted via `options.signal`.
      */
     async run(
         data: Record<string, any> = {},
@@ -475,13 +491,25 @@ export class Container<
     }
 
     /**
-     * @throws ValidupError
+     * Synchronous variant of {@link Container.run}. Use it for purely
+     * synchronous validator graphs where the microtask overhead of `await`
+     * per mount matters (e.g. driving a reactive UI without a `pending`
+     * flicker on every keystroke).
      *
-     * Synchronous variant of `run()`. Throws synchronously if any validator
-     * returns a thenable, or if a nested container does not implement
-     * `runSync`. Use it for purely synchronous validator graphs where the
-     * microtask overhead of `await` per mount matters (e.g. driving a
-     * reactive UI without a `pending` flicker).
+     * Each mounted validator's return value MUST NOT be a thenable, and every
+     * nested container MUST implement `runSync`. Either violation throws
+     * `RunSyncViolationError` (structural — distinct from validation
+     * failures), so the diagnostic is surfaced verbatim rather than wrapped
+     * into a `ValidupError`. The companion {@link Container.safeRunSync}
+     * still rethrows these for the same reason.
+     *
+     * No `parallel` variant — synchronous graphs don't benefit from
+     * concurrency, and `Promise.allSettled` is async by definition.
+     *
+     * @throws ValidupError on validation failure.
+     * @throws RunSyncViolationError when a validator returns a Promise or a
+     *         nested container does not implement `runSync`.
+     * @throws signal.reason when aborted via `options.signal`.
      */
     runSync(
         data: Record<string, any> = {},

--- a/packages/validup/src/container/module.ts
+++ b/packages/validup/src/container/module.ts
@@ -153,12 +153,18 @@ export class Container<
      *   variants for graphs where every validator (and every nested container's
      *   `runSync`) is synchronous.
      *
-     * Rethrows `options.signal.reason` when the run is aborted — abort is
-     * surfaced as the signal's reason, not folded into the issue tree, so
-     * callers can distinguish "validation failed" from "operation cancelled".
+     * Aborts surface verbatim — the abort is detected via `signal.throwIfAborted()`
+     * between mounts (which throws `signal.reason`), and any error raised by a
+     * mid-flight validator during an aborted run is re-thrown as-is rather than
+     * folded into the issue tree. Callers can therefore distinguish "validation
+     * failed" from "operation cancelled," but should not assume the thrown value
+     * is always `signal.reason` — a validator that throws its own error before
+     * the next abort check produces that error instead.
      *
      * @throws ValidupError on validation failure.
-     * @throws signal.reason when aborted via `options.signal`.
+     * @throws signal.reason when the abort check fires between mounts.
+     * @throws (mid-flight validator error) when a validator throws during an
+     *         already-aborted run — re-raised as-is rather than wrapped.
      */
     async run(
         data: Record<string, any> = {},
@@ -506,10 +512,18 @@ export class Container<
      * No `parallel` variant — synchronous graphs don't benefit from
      * concurrency, and `Promise.allSettled` is async by definition.
      *
+     * Aborts surface the same way as {@link Container.run}: the
+     * `signal.throwIfAborted()` check between mounts throws `signal.reason`,
+     * and a mid-flight validator throw during an already-aborted run is
+     * re-raised verbatim. Don't assume the thrown value is always
+     * `signal.reason`.
+     *
      * @throws ValidupError on validation failure.
      * @throws RunSyncViolationError when a validator returns a Promise or a
      *         nested container does not implement `runSync`.
-     * @throws signal.reason when aborted via `options.signal`.
+     * @throws signal.reason when the abort check fires between mounts.
+     * @throws (mid-flight validator error) when a validator throws during an
+     *         already-aborted run.
      */
     runSync(
         data: Record<string, any> = {},


### PR DESCRIPTION
## Summary

Pre-1.0 follow-up from the audit alignment conversation — S1 resolution: **keep the five-method matrix, tighten the docs.**

- **`packages/validup/README.md`** — new "Run Modes" section with a reference table mapping (sync/async × throw/safe × sequential/parallel) onto the five call shapes. The deliberate omission of sync + parallel is called out explicitly. The existing Parallel Execution / Safe Run / Sync Fast Path sections become sub-sections under it with the detail intact.
- **`packages/validup/src/container/module.ts`** — `Container.run` and `Container.runSync` JSDocs tightened to match the contract clarity already applied to `IContainer.safeRun*` in the audit PR. Cross-links the four sibling methods, names the throw cases (`ValidupError`, `RunSyncViolationError`, `signal.reason`), and notes which throws bypass the issue-folding path.

No code-behavior change. Stacks against [#375](https://github.com/tada5hi/validup/pull/375) (the audit PR) but is independent — branched from master.

## Test plan

- [x] `npm run build --workspace=validup` — clean
- [x] `npm run lint` — clean
- [x] `npm run test --workspace=validup` — 109 tests pass (baseline; no test changes in this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded container execution modes documentation, covering sync/async execution options, error handling strategies (exception-based vs. safe Result patterns), and sequential/parallel behavior.
  * Enhanced API documentation with clarified synchronous validator requirements, structural failure handling, and abort signal behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/validup/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->