### PR TITLE
refactor(vue): extract collector tree into private useValidupCollector

### DIFF
--- a/packages/vue/src/helpers/collector.ts
+++ b/packages/vue/src/helpers/collector.ts
@@ -90,7 +90,12 @@ export function useValidupCollector(options: CollectorOptions): ValidupCollector
 
     // Scoped parent/child injection — same-scope parents see same-scope
     // descendants; the unscoped key continues to behave as before.
-    const ownInjectionKey = options.scope ?
+    //
+    // Test for `undefined` explicitly rather than truthy — an empty-string
+    // scope is unusual but the consumer has clearly opted in to scoping by
+    // passing the option, and it should get its own `Symbol.for()` key rather
+    // than being silently collapsed back to the unscoped default.
+    const ownInjectionKey = options.scope !== undefined ?
         Symbol.for(`validup:parent:${options.scope}`) :
         PARENT_INJECTION_KEY;
 

--- a/packages/vue/src/helpers/collector.ts
+++ b/packages/vue/src/helpers/collector.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ObjectLiteral } from 'validup';
+import {
+    getCurrentInstance,
+    getCurrentScope,
+    inject,
+    onScopeDispose,
+    provide,
+} from 'vue';
+import type { ParentRegistry, ValidupComposable } from '../types';
+import { PARENT_INJECTION_KEY } from './child';
+
+/**
+ * Subset of `ValidupComposableOptions` that drives parent/child collector
+ * behaviour. Carved out so the collector helper has a focused signature and
+ * is testable in isolation; the public composable surface continues to
+ * accept the full options object.
+ */
+export interface CollectorOptions {
+    /** Identifier under which this composable registers with an ancestor collector. */
+    name?: string;
+    /** Partition key — same-scope parents collect same-scope descendants only. */
+    scope?: string;
+    /**
+     * Skip BOTH `inject()` and `provide()` — invisible to ancestors *and*
+     * descendants.
+     */
+    detached?: boolean;
+    /**
+     * Skip `inject()` (don't attach to a higher-level parent) but still
+     * `provide()` self so descendants can register. The common aggregation-root
+     * shape.
+     */
+    stopPropagation?: boolean;
+}
+
+/**
+ * Internal — return shape of `useValidupCollector`. The composable uses
+ * `childRegistry` to satisfy `$getResultsForChild` and calls `attach(self)`
+ * once its own object literal is built so parent registration sees the
+ * already-shaped composable rather than a half-constructed reference.
+ */
+export interface ValidupCollector {
+    /**
+     * Live map of name → composable for child forms that registered with
+     * this collector. Plain `Map` (not `reactive()`) on purpose — children
+     * are consumed imperatively (typically inside a submit handler), and a
+     * reactive wrapper would unwrap nested refs in the child composable's
+     * public type.
+     */
+    readonly childRegistry: Map<string, ValidupComposable<ObjectLiteral>>;
+
+    /**
+     * Register `composable` with the parent collector (if any) under
+     * `options.name`. Idempotent — calling it more than once with the same
+     * collector instance has the same effect as calling it once. Hooks
+     * `onScopeDispose` to auto-unregister when the owning effect scope tears
+     * down.
+     */
+    attach(composable: ValidupComposable<ObjectLiteral>): void;
+}
+
+/**
+ * Carves the parent/child collector concern out of `useValidup`. Builds the
+ * `childRegistry`, calls `inject()` / `provide()` according to the flags,
+ * and exposes `attach(composable)` so the caller can register the
+ * fully-built composable with the parent at the end of setup.
+ *
+ * Not re-exported from the package barrel — this is an internal helper.
+ * Promote to a public export only when an external consumer surfaces a
+ * concrete need for the split.
+ */
+export function useValidupCollector(options: CollectorOptions): ValidupCollector {
+    const childRegistry = new Map<string, ValidupComposable<ObjectLiteral>>();
+
+    const ownRegistry: ParentRegistry = {
+        register(name, child) {
+            childRegistry.set(name, child);
+        },
+        unregister(name) {
+            childRegistry.delete(name);
+        },
+    };
+
+    // Scoped parent/child injection — same-scope parents see same-scope
+    // descendants; the unscoped key continues to behave as before.
+    const ownInjectionKey = options.scope ?
+        Symbol.for(`validup:parent:${options.scope}`) :
+        PARENT_INJECTION_KEY;
+
+    // Only provide / inject within a component setup context.
+    //
+    // - `detached: true` skips BOTH `inject()` and `provide()` — the
+    //   composable is invisible to ancestors *and* descendants.
+    // - `stopPropagation: true` skips `inject()` (won't register with a
+    //   parent) but still calls `provide()` so descendants can register
+    //   with this composable. The common "root of an aggregation tree" flag.
+    const inComponent = getCurrentInstance() !== null;
+    let parent: ParentRegistry | undefined;
+    if (inComponent && !options.detached) {
+        if (!options.stopPropagation) {
+            parent = inject(ownInjectionKey, undefined);
+        }
+        provide(ownInjectionKey, ownRegistry);
+    }
+
+    return {
+        childRegistry,
+        attach(composable) {
+            if (inComponent && parent && options.name) {
+                parent.register(options.name, composable);
+                if (getCurrentScope()) {
+                    onScopeDispose(() => parent!.unregister(options.name as string));
+                }
+            }
+        },
+    };
+}

--- a/packages/vue/src/module.ts
+++ b/packages/vue/src/module.ts
@@ -7,12 +7,9 @@
 
 import {
     computed,
-    getCurrentInstance,
     getCurrentScope,
-    inject,
     isRef,
     onScopeDispose,
-    provide,
     reactive,
     ref,
     toRaw,
@@ -34,13 +31,12 @@ import {
     isIssueGroup,
     isValidupError,
 } from 'validup';
-import { PARENT_INJECTION_KEY } from './helpers/child';
+import { useValidupCollector } from './helpers/collector';
 import type {
-    ContainerInput, 
-    FieldState, 
-    ParentRegistry, 
-    StateInput, 
-    ValidupComposable, 
+    ContainerInput,
+    FieldState,
+    StateInput,
+    ValidupComposable,
     ValidupComposableOptions,
 } from './types';
 
@@ -215,43 +211,17 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral, C = unknown>
     }
 
     // ---- nested form registry ----------------------------------------------
-    // Plain Map (not reactive) — `$getResultsForChild` is consumed imperatively
-    // (e.g. inside a submit handler), and Vue's `reactive()` would unwrap the
-    // child composable's refs, mangling the public type.
+    // Parent/child collector tree carved out into a private helper so the
+    // wiring (inject/provide, scope-keyed Symbol, attach-on-mount,
+    // unregister-on-dispose) lives in one place and `useValidup` stays
+    // focused on validation state. See helpers/collector.ts.
 
-    const childRegistry = new Map<string, ValidupComposable<any>>();
-
-    const ownRegistry: ParentRegistry = {
-        register(name, child) {
-            childRegistry.set(name, child);
-        },
-        unregister(name) {
-            childRegistry.delete(name);
-        },
-    };
-
-    // Scoped parent/child injection — same-scope parents see same-scope
-    // descendants; the unscoped key continues to behave as before.
-    const ownInjectionKey = options.scope ?
-        Symbol.for(`validup:parent:${options.scope}`) :
-        PARENT_INJECTION_KEY;
-
-    // Only provide / inject within a component setup context.
-    //
-    // - `detached: true` skips BOTH `inject()` and `provide()` — the
-    //   composable is invisible to ancestors *and* descendants.
-    // - `stopPropagation: true` skips `inject()` (won't register with a
-    //   parent) but still calls `provide()` so descendants can register
-    //   with this composable. This is the common "this is the root of an
-    //   aggregation tree" flag.
-    const inComponent = getCurrentInstance() !== null;
-    let parent: ParentRegistry | undefined;
-    if (inComponent && !options.detached) {
-        if (!options.stopPropagation) {
-            parent = inject(ownInjectionKey, undefined);
-        }
-        provide(ownInjectionKey, ownRegistry);
-    }
+    const collector = useValidupCollector({
+        name: options.name,
+        scope: options.scope,
+        detached: options.detached,
+        stopPropagation: options.stopPropagation,
+    });
 
     // ---- per-path issue selection ------------------------------------------
 
@@ -549,16 +519,12 @@ export function useValidup<T extends ObjectLiteral = ObjectLiteral, C = unknown>
         $reset,
         $validate,
         setExternalIssues,
-        $getResultsForChild: <C extends ObjectLiteral = ObjectLiteral>(name: string) => childRegistry.get(name) as ValidupComposable<C> | undefined,
+        $getResultsForChild: <C extends ObjectLiteral = ObjectLiteral>(name: string) =>
+            collector.childRegistry.get(name) as ValidupComposable<C> | undefined,
         fields,
     };
 
-    if (inComponent && parent && options.name) {
-        parent.register(options.name, composable);
-        if (getCurrentScope()) {
-            onScopeDispose(() => parent!.unregister(options.name as string));
-        }
-    }
+    collector.attach(composable);
 
     if (getCurrentScope()) {
         // Abort in-flight scheduled runs AND drop any pending debounced


### PR DESCRIPTION
## Summary

Pre-1.0 follow-up from the audit alignment conversation — S7 resolution: **extract the collector concern as a private helper; keep the public `ValidupComposable<T>` shape unchanged.**

The 580-line `useValidup` composable bundled seven concerns at once. The parent/child collector concern — `childRegistry`, scope-keyed injection key, `inject()` / `provide()` gated by `detached` / `stopPropagation`, and the attach-on-mount + `onScopeDispose`-unregister pair — moves to a private helper at `packages/vue/src/helpers/collector.ts`.

`useValidup` now:

- Calls `useValidupCollector(options)` early in setup to wire up parent `inject()` and self `provide()`.
- Reads `collector.childRegistry` to satisfy `$getResultsForChild`.
- Calls `collector.attach(composable)` once the composable object literal is built so the parent registration sees the fully-shaped composable rather than a partial reference.

`useValidupCollector` is **not** re-exported from `helpers/index.ts` or the package barrel — it's an internal helper. Promote it to a public export only when an external consumer surfaces a concrete need for the split.

Branched from master — independent of [#375](https://github.com/tada5hi/validup/pull/375) (audit PR) and [#376](https://github.com/tada5hi/validup/pull/376) (run-modes docs).

## Test plan

- [x] `npm run build --workspace=@validup/vue` — clean
- [x] `npm run lint` — clean
- [x] `npm run test --workspace=@validup/vue` — 59 tests pass (no test changes; behavior is unchanged)

## Why no public split?

Per the alignment conversation on S7: there's no consumer asking for a separate `useValidupCollector` export. Carving the internal concern out gets the testability win and shortens the file; promoting it to public surface before a real need would commit 1.0 to a shape we can't yet evaluate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal Vue form composition helpers for more reliable parent/child registration, cleaner lifecycle handling, and easier maintenance without changing public APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/validup/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->