### PR TITLE
docs(express-validator): clarify createValidationChain as deliberate alias

### DIFF
--- a/packages/express-validator/README.md
+++ b/packages/express-validator/README.md
@@ -56,6 +56,8 @@ const valid = await container.run({ tags: ['typescript', 'validation'] });
 
 `createValidationChain()` returns an express-validator `body()` chain — pre-bound to read the value validup hands the validator. Build your rules on top of it like any other express-validator chain.
 
+> ℹ️ **Deliberate alias.** `createValidationChain()` is a thin wrapper around express-validator's `body()` and adds no behavior on top of it. The function is kept for stylistic consistency with the rest of the `@validup/express-validator` API; calling `body()` from `express-validator` directly is equivalent and fully supported. Pick whichever spelling you find clearer for your codebase.
+
 ## Real-World Pattern
 
 The dominant pattern is to subclass `Container<T>` and register chains inside `initialize()`:

--- a/packages/express-validator/src/chain.ts
+++ b/packages/express-validator/src/chain.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
@@ -7,6 +7,21 @@
 
 import { type ValidationChain, body } from 'express-validator';
 
+/**
+ * Build a fresh express-validator `body()` chain.
+ *
+ * Deliberate alias for `express-validator`'s own `body()` — kept for
+ * stylistic consistency with the rest of the `@validup/express-validator`
+ * API. Calling `body()` from `express-validator` directly is equivalent and
+ * fully supported; reach for `createValidationChain()` if you prefer to
+ * keep all chain creation behind the validup-integration package, or
+ * import `body()` directly if you'd rather skip the indirection.
+ *
+ * No behavior is added on top of `body()` — there is no preset, no
+ * sanitizer, no validup-aware customization. If a future minor version
+ * adds behavior, it will be opt-in via parameters; the no-arg call will
+ * stay equivalent to `body()`.
+ */
 export function createValidationChain() : ValidationChain {
     return body();
 }


### PR DESCRIPTION
## Summary

Pre-1.0 follow-up from the audit alignment conversation — N2 resolution: **keep `createValidationChain` as a deliberate stylistic alias; make the intent explicit in docs.**

`createValidationChain()` is a one-line wrapper around express-validator's `body()` and adds no behavior on top of it. The audit flagged this as API noise, but the alignment conversation landed on keeping it (the function is integrated into the README's Quick Start, Real-World Pattern, and Per-Context Chains sections, and 6+ test cases — churn outweighed the cleanup).

This PR makes the intent explicit so future readers don't wonder why the function exists or assume it's doing something invisible:

- **`packages/express-validator/src/chain.ts`** — JSDoc on `createValidationChain()` now states it's a deliberate alias for `body()`, confirms there's no preset / sanitizer / validup-aware customization, and notes that any future behavior will be opt-in via parameters (no-arg calls will stay equivalent).
- **`packages/express-validator/README.md`** — one-line aside next to the Quick Start example pointing out the alias intent and that calling `body()` directly is equivalent and fully supported.

Branched from master — independent of [#375](https://github.com/tada5hi/validup/pull/375), [#376](https://github.com/tada5hi/validup/pull/376), and [#377](https://github.com/tada5hi/validup/pull/377).

## Test plan

- [x] `npm run build --workspace=@validup/express-validator` — clean
- [x] `npm run lint` — clean
- [x] `npm run test --workspace=@validup/express-validator` — 10 tests pass (baseline; no test changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated documentation to clarify that the validation chain API is a stylistic equivalent to the underlying library, with no additional runtime behavior. Users now have clearer guidance on when and how to use the validation chain API directly versus importing from the parent library.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/validup/pull/378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->