### PR TITLE
feat!: graduate validup ecosystem to 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ db.sqlite
 cache
 .nx
 .agents/plans
-.claude/settings.local.json
+.claude/
 
 # VitePress
 docs/src/.vitepress/cache

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ A composable, path-based validation library for TypeScript.
 
 Mount validators and nested containers onto object paths, run them in groups, collect structured issues, and bridge to your favorite validator (zod, express-validator) or framework (Vue) — all without decorators or schema DSLs.
 
-> 🚧 **Work in Progress**
->
-> Validup is currently under active development and is not yet ready for production.
-
 ## Core Philosophy
 
 Most validation libraries make you choose between two extremes: a schema DSL that bakes in every rule, or a hand-rolled function that tangles parsing, validation, and transformation. Validup picks a different point — **mount any validator function onto any path of any input, compose containers, and let the runtime handle path expansion, error aggregation, and group filtering.** You bring the validators (or wrap an existing library via an integration package); validup orchestrates them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "vitest": "^4.1.2"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
             }
         },
         "docs": {
@@ -40,7 +40,7 @@
                 "vue": "^3.5.34"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
             }
         },
         "node_modules/@algolia/abtesting": {
@@ -9163,18 +9163,15 @@
             "name": "@validup/express-validator",
             "version": "0.3.3",
             "license": "Apache-2.0",
-            "dependencies": {
-                "smob": "^1.6.2",
-                "validup": "^0.3.0"
-            },
             "devDependencies": {
                 "express-validator": "^7.3.1"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
             },
             "peerDependencies": {
-                "express-validator": "^7.3.1"
+                "express-validator": "^7.3.1",
+                "validup": "^0.3.0"
             }
         },
         "packages/routup": {
@@ -9203,14 +9200,16 @@
             "version": "0.1.1",
             "license": "Apache-2.0",
             "dependencies": {
-                "@standard-schema/spec": "^1.1.0",
-                "validup": "^0.3.0"
+                "@standard-schema/spec": "^1.1.0"
             },
             "devDependencies": {
                 "zod": "^4.4.3"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
+            },
+            "peerDependencies": {
+                "validup": "^0.3.0"
             }
         },
         "packages/validup": {
@@ -9222,25 +9221,23 @@
                 "smob": "^1.6.2"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
             }
         },
         "packages/vue": {
             "name": "@validup/vue",
             "version": "0.2.0",
             "license": "Apache-2.0",
-            "dependencies": {
-                "validup": "^0.3.0"
-            },
             "devDependencies": {
                 "@vue/test-utils": "^2.4.10",
                 "happy-dom": "^15.11.7",
                 "vue": "^3.5.34"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
             },
             "peerDependencies": {
+                "validup": "^0.3.0",
                 "vue": "^3.3"
             }
         },
@@ -9248,17 +9245,15 @@
             "name": "@validup/zod",
             "version": "0.2.5",
             "license": "Apache-2.0",
-            "dependencies": {
-                "validup": "^0.3.0"
-            },
             "devDependencies": {
                 "zod": "^4.4.3"
             },
             "engines": {
-                "node": ">=22.0.0"
+                "node": ">=24.0.0"
             },
             "peerDependencies": {
-                "zod": "^3.25.0 || ^4.0.0"
+                "validup": "^0.3.0",
+                "zod": "^4.0.0"
             }
         }
     }

--- a/packages/express-validator/README.md
+++ b/packages/express-validator/README.md
@@ -10,10 +10,6 @@ A [validup](https://www.npmjs.com/package/validup) integration for [express-vali
 
 Wrap any express-validator `ValidationChain` as a validup `Validator`, mount it on a `Container` path, and let validup orchestrate path expansion, group filtering, and structured error reporting while express-validator drives the rule chain.
 
-> 🚧 **Work in Progress**
->
-> Validup is currently under active development and is not yet ready for production.
-
 **Table of Contents**
 
 - [Installation](#installation)
@@ -33,6 +29,7 @@ npm install @validup/express-validator validup express-validator --save
 
 | Peer dependency     | Supported versions |
 |---------------------|--------------------|
+| `validup`           | `^1.0.0`           |
 | `express-validator` | `^7.3.1`           |
 
 ## Quick Start
@@ -178,7 +175,7 @@ What's covered by semver:
 
 Peer dependency policy:
 
-- `express-validator ^7.3.1`.
+- `validup ^1.0.0`, `express-validator ^7.3.1`.
 
 Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 

--- a/packages/express-validator/package.json
+++ b/packages/express-validator/package.json
@@ -36,13 +36,11 @@
     },
     "keywords": [],
     "license": "Apache-2.0",
-    "dependencies": {
-        "validup": "^0.3.0"
-    },
     "devDependencies": {
         "express-validator": "^7.3.1"
     },
     "peerDependencies": {
+        "validup": "^0.3.0",
         "express-validator": "^7.3.1"
     },
     "publishConfig": {

--- a/packages/standard-schema/README.md
+++ b/packages/standard-schema/README.md
@@ -4,10 +4,6 @@ A [validup](https://www.npmjs.com/package/validup) integration for any [Standard
 
 Mount any Standard Schema as a validup `Validator` on a `Container` path; validup handles path expansion, group filtering, optional/default semantics, and error aggregation while the underlying library does the actual parsing.
 
-> 🚧 **Work in Progress**
->
-> Validup is currently under active development and is not yet ready for production.
-
 **Table of Contents**
 
 - [Installation](#installation)
@@ -119,7 +115,7 @@ What's covered by semver:
 
 If you need vendor-specific fields like zod's `expected` / `received`, use [`@validup/zod`](https://npmjs.com/package/@validup/zod) instead — both packages can coexist.
 
-Peer dependency policy: no runtime peer deps. The adapter operates against the `@standard-schema/spec` types only and works against any spec-compatible schema instance (zod 3.24+, valibot, arktype, effect-schema, …).
+Peer dependency policy: `validup ^1.0.0`. No peer dep on a specific schema library — the adapter operates against the `@standard-schema/spec` types and works against any spec-compatible schema instance (zod 3.24+, valibot, arktype, effect-schema, …).
 
 Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 

--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -44,11 +44,13 @@
     ],
     "license": "Apache-2.0",
     "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "validup": "^0.3.0"
+        "@standard-schema/spec": "^1.1.0"
     },
     "devDependencies": {
         "zod": "^4.4.3"
+    },
+    "peerDependencies": {
+        "validup": "^0.3.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -10,10 +10,6 @@ A composable, path-based validation library for TypeScript.
 
 Mount any validator function (or nested container) onto any path of your input, run them in groups, collect structured issues, and bridge to existing libraries via integration packages. No decorators, no schema DSL, no metadata reflection.
 
-> 🚧 **Work in Progress**
->
-> Validup is currently under active development and is not yet ready for production.
-
 **Table of Contents**
 
 - [Installation](#installation)

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -10,10 +10,6 @@ A [validup](https://www.npmjs.com/package/validup) integration for [Vue 3](https
 
 Drive form validation from a validup `Container<T>` with a vuelidate-shaped composable. The same validator runs on the **server** and the **client** — no rule duplication, no schema drift.
 
-> 🚧 **Work in Progress**
->
-> Validup is currently under active development and is not yet ready for production.
-
 **Table of Contents**
 
 - [Installation](#installation)
@@ -44,10 +40,10 @@ Drive form validation from a validup `Container<T>` with a vuelidate-shaped comp
 npm install @validup/vue validup vue --save
 ```
 
-| Dependency      | Supported versions |
+| Peer dependency | Supported versions |
 |-----------------|--------------------|
-| `validup`       | `^0.3.0` (runtime `dependencies` entry, not peer — will move to peer + `^1.0.0` at the coordinated 1.0 cut) |
-| `vue`           | `^3.3` (peer)      |
+| `validup`       | `^1.0.0`           |
+| `vue`           | `^3.3`             |
 
 ## Quick Start
 
@@ -471,10 +467,9 @@ Internal (no semver guarantee):
 - The `Proxy`-backed `fields` accessor's exact dispatch (`getOwnPropertyDescriptor` returning a data descriptor with `value`, etc.) — observable behavior (per-field state, reactive key tracking) is stable; the underlying mechanism is not.
 - The run-id / abort token internals.
 
-Dependency policy:
+Peer dependency policy:
 
-- `validup` — currently bundled as a runtime `dependencies` entry at `^0.3.0`. At the coordinated 1.0 cut this moves to `peerDependencies` at `^1.0.0` so consumers don't carry two copies of the core.
-- `vue` — peer dependency, `^3.3`.
+- `validup ^1.0.0`, `vue ^3.3`. Both must be installed by the consumer; `@validup/vue` does not bundle either.
 - `@vueuse/core` — transitive runtime dependency.
 
 Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -42,15 +42,13 @@
         "composable"
     ],
     "license": "Apache-2.0",
-    "dependencies": {
-        "validup": "^0.3.0"
-    },
     "devDependencies": {
         "@vue/test-utils": "^2.4.10",
         "happy-dom": "^15.11.7",
         "vue": "^3.5.34"
     },
     "peerDependencies": {
+        "validup": "^0.3.0",
         "vue": "^3.3"
     },
     "publishConfig": {

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -14,10 +14,6 @@ Wrap any zod schema as a validup `Validator`, mount it on a `Container` path, an
 >
 > [`@validup/standard-schema`](https://npmjs.com/package/@validup/standard-schema) covers zod via the [Standard Schema](https://standardschema.dev) protocol and works the same against valibot, arktype, and effect-schema. Pick `@validup/zod` when you specifically need `expected`/`received` on issues or the bidirectional `validup ↔ zod` mapping.
 
-> 🚧 **Work in Progress**
->
-> Validup is currently under active development and is not yet ready for production.
-
 **Table of Contents**
 
 - [Installation](#installation)
@@ -38,6 +34,7 @@ npm install @validup/zod validup zod --save
 
 | Peer dependency | Supported versions  |
 |-----------------|---------------------|
+| `validup`       | `^1.0.0`            |
 | `zod`           | `^4.0.0`            |
 
 > ℹ️ **zod 3 support was dropped in `@validup/zod@1.0`.** The adapter's `ZodIssue` type alias resolves to `zod/v4/core`'s `$ZodRawIssue`, which is not available in zod 3. Stay on `@validup/zod@<1` if you cannot upgrade zod; otherwise upgrade zod to `^4.0.0` alongside this package.
@@ -178,7 +175,7 @@ Known lossy behavior:
 
 Peer dependency policy:
 
-- `zod ^4.0.0`. zod 3.x was dropped in `@validup/zod@1.0` because the adapter's `ZodIssue` type alias resolves to `zod/v4/core`, which is not available in zod 3.
+- `validup ^1.0.0`, `zod ^4.0.0`. zod 3.x was dropped in `@validup/zod@1.0` because the adapter's `ZodIssue` type alias resolves to `zod/v4/core`, which is not available in zod 3.
 
 Deprecation policy: matches [`validup`](https://npmjs.com/package/validup) — at least one minor release of `@deprecated` notice before removal in a major.
 

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -36,13 +36,11 @@
     },
     "keywords": [],
     "license": "Apache-2.0",
-    "dependencies": {
-        "validup": "^0.3.0"
-    },
     "devDependencies": {
         "zod": "^4.4.3"
     },
     "peerDependencies": {
+        "validup": "^0.3.0",
         "zod": "^4.0.0"
     },
     "publishConfig": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,5 @@
 {
     "release-type": "node",
-    "bump-minor-pre-major": true,
-    "bump-patch-for-minor-pre-major": true,
     "initial-version": "0.1.0",
     "packages": {
         "packages/validup": {"component": "validup"},


### PR DESCRIPTION
## Summary

Coordinated 1.0 cut for **all five published packages** in lockstep:

| Package | 0.x | 1.0 |
|---------|-----|-----|
| `validup` | 0.3.0 | **1.0.0** |
| `@validup/zod` | 0.2.5 | **1.0.0** |
| `@validup/standard-schema` | 0.1.1 | **1.0.0** |
| `@validup/express-validator` | 0.3.3 | **1.0.0** |
| `@validup/vue` | 0.2.0 | **1.0.0** |

Merging this PR causes release-please to open the actual version-bump PR with CHANGELOG entries for each component. Merging *that* PR triggers monoship to publish to npm.

## Breaking changes

1. **`validup` moves from `dependencies` to `peerDependencies` in every integration package.** Consumers now install `validup` explicitly alongside any adapter they use. This eliminates the risk of two copies of `validup` in a consumer's lockfile and aligns with how comparable adapter ecosystems (zod's adapters, ts-rest, …) handle their core.

   Migration:
   ```diff
   - npm install @validup/zod
   + npm install @validup/zod validup
   ```

   Peer ranges are committed at `^0.3.0` so the workspace install resolves locally today. release-please's `node-workspace` plugin (with `updatePeerDependencies: true`) bumps all peer ranges to `^1.0.0` as part of the release PR — so the published 1.0 artifacts will declare `validup ^1.0.0`. Until that release PR merges, READMEs document the post-release state.

2. **`release-please-config.json`**: drop `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true`. Future `feat!` commits now bump major (1.x → 2.x) instead of minor. `feat:` and `fix:` keep their standard semver semantics.

## Docs

- Remove "🚧 Work in Progress" banners from the root README and all five package READMEs.
- Each package README's peer-dependency table now lists `validup ^1.0.0` alongside the framework / library peer.
- `@validup/vue`'s forward-looking "will move to peer + ^1.0.0 at the coordinated 1.0 cut" notes are replaced with the current state.

Stability sections (committed in #375) describe what 1.0 commits to in detail.

## What's NOT in this PR

The remaining audit follow-ups in `.agents/plans/1.0-followups.md` (local working doc) stay deferred for post-1.0:

- **N1** — `@validup/standard-schema` vs `@validup/zod` consolidation
- **N3** — `@validup/express-validator` single-field auto-unwrap behavior
- **N4** — `Container.canRunSync()` introspection

None of these block 1.0 — each is either a design decision waiting on a real consumer signal (N1, N3) or a purely additive future enhancement (N4).

## Test plan

- [x] `npm install` — workspace resolves correctly with the new peer dep shape
- [x] `npm run test` — all packages pass (validup 118, vue 59, express-validator 10, standard-schema 6, zod 8)
- [x] `npm run lint` — clean
- [x] `npm run build` — all 5 publishable packages + docs site build clean
- [ ] After merge: verify release-please opens a release PR bumping all 5 components to 1.0.0
- [ ] After release PR merge: verify monoship publishes the 1.0 versions to npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed production-readiness notices from multiple package READMEs.
  * Updated installation guides and peer dependency specifications across packages.

* **Chores**
  * Reclassified `validup` to peer dependency status across multiple packages.
  * Updated build and release management configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/validup/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->