### PR TITLE
refactor(validup): derive run and runSync from one shared twin body

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -83,8 +83,7 @@ The cache is threaded through nested container `.run()` calls so a single `Resul
 
 ### Run-variant integration
 
-- **`run`** — synchronous cache check before `await item.data(ctx)`; on miss, an inner try/catch writes the outcome (success or failure) before re-raising into the outer catch.
-- **`runSync`** — same shape, plus the `RunSyncViolationError` carve-out (never cached — structural).
+- **`run` / `runSync`** — one code path (the shared twin body): synchronous cache check before the validator effect; on miss, an inner `try`/`catch` around the `yield*` writes the outcome (success or failure) before re-raising into the outer catch. `RunSyncViolationError`s are carved out of the failure write (never cached — structural).
 - **`runParallel`** — cache check happens before each per-mount promise is created. On hit the slot is materialized as `Promise.resolve(value)` / `Promise.reject(error)` so the existing `Promise.allSettled` merge loop handles cached and fresh outcomes identically. Cache writes happen inside the async wrapper that runs the validator, so the entry is persisted before the promise settles.
 
 ## Container
@@ -145,11 +144,42 @@ For each mounted item, in registration order:
 
 ### Execution variants
 
-- **`run`** (default) — sequential `await` per mount.
-- **`runSync`** — same loop without `await`. Validator return values must not be thenable; nested containers must implement `runSync`. Violations throw `RunSyncViolationError` (duck-type guard: `isRunSyncViolation`) and are *not* folded into the issue list.
+- **`run`** (default) — sequential `await` per mount. `runTwinAsync(this.runBody(...))`.
+- **`runSync`** — the *same* loop without `await`: `runTwinSync(this.runBody(...))`. Validator return values must not be thenable; nested containers must implement `runSync`. Violations throw `RunSyncViolationError` (duck-type guard: `isRunSyncViolation`) and are *not* folded into the issue list.
 - **`runParallel`** (selected via `ContainerRunOptions.parallel: true`) — eagerly kicks off every mount's promise, then awaits them with `Promise.allSettled`. Issues are merged in mount-registration order regardless of which validator rejects first. Trade-off: parallel mode reads `value` from the input `data` only, skipping the sequential mode's `hasOwnProperty(output, key)` chain-read for sanitize-then-validate patterns.
 
-All three variants share the private helpers `resolveContainerFilters` / `recordMountError` / `finalizeOutput` / `wrapSafeRunError` / `resolveCachedOutcome` / `writeCachedOutcome` so issue handling and cache consultation stay consistent.
+#### The sync/async twin body (`runBody`)
+
+`run` and `runSync` are **not two loops** — they are two drivers over one private generator, `Container.runBody`, using the internal twin protocol in `src/utils/twin.ts` (ported from [`tada5hi/locter`](https://github.com/tada5hi/locter)'s `src/utils/twin.ts`; same shape, one deviation: validup's async thunk may return a bare value as well as a promise, because a `Validator` is free to be synchronous).
+
+A twin body yields **effect pairs** — `yield* op(asyncThunk, syncThunk)` — and `runTwinAsync` / `runTwinSync` execute the side they stand for. Effect errors are re-entered via `Generator.throw`, so a `try`/`catch` wrapping a `yield*` site behaves identically in both variants; that is what lets the cache-write and `collectExecutionFailure` blocks exist once. Bodies compose via `yield*` delegation.
+
+`runBody` yields exactly **two** effects — the loop's only impure edges:
+
+| Effect | async thunk | sync thunk |
+|---|---|---|
+| nested container | `child.run(input, childOptions)` | `child.runSync(...)`, throwing `RunSyncViolationError` when the method is absent |
+| validator | `validator(ctx)` | `validator(ctx)`, throwing `RunSyncViolationError` when the return value is thenable (`isThenable`) |
+
+Both structural probes therefore live *inside the sync thunk*, where they belong — the async side cannot produce them. Everything else (abort checks, group filter, path expansion, path filter, optional resolution, cache gating, issue collection, `oneOf` branch wrapping, `finalizeOutput`) exists exactly once.
+
+**`runParallel` deliberately does NOT share the body.** A generator is sequential by construction; expressing "launch every mount, then settle" through it would mean yielding batches *and* giving up the chain-read that distinguishes sequential mode. Instead it shares every per-key helper:
+
+| Helper | Answers |
+|---|---|
+| `prepareMountKey(item, key, options, pathsToInclude, pathsToExclude)` | `keyParts` / `pathRelative` / `pathAbsolute` / include-exclude verdict (`MountKeyPlan`) |
+| `resolveOptionalDirective(item, value, options)` | skip or proceed, and what a skipped key writes (`OptionalDirective`) |
+| `buildChildRunOptions(options, key, plan, pathsStrict, parallel?)` | the child-container forward bag — one source of truth for what a nested container inherits |
+| `buildValidatorContext(key, plan, value, data, options)` | the `ValidatorContext` handed to a validator |
+| `resolveCachedOutcome` / `writeCachedOutcome` | cache gating (see [Result cache](#result-cache-packagesvalidupsrccache)) |
+
+`prepareMountKey` deliberately does **not** read the mount's input `value` — the sequential-vs-parallel value-source asymmetry is a documented behavioural difference, so it stays in the caller and the helper stays pure.
+
+All variants additionally share `resolveContainerFilters` / `resolvePathsStrict` / `assertPathsStrict` / `collectExecutionFailure` / `wrapBranchForOneOf` / `finalizeOutput` / `wrapSafeRunError`, so issue handling and cache consultation stay consistent.
+
+**When adding a run or mount option**, thread it through the twin body plus (if a child inherits it) `buildChildRunOptions` — two edits, not six. `runParallel` picks up anything the shared helpers resolve for free; only genuinely scheduling-specific behaviour needs a second touch there.
+
+One behaviour was unified in passing: the "don't cache a `RunSyncViolationError`" guard was previously `runSync`-only and now applies in both variants. It is unreachable on the async side except for the pathological case of a validator letting a `RunSyncViolationError` escape — which `collectExecutionFailure` already rethrows structurally, so not caching it is the consistent reading.
 
 ### Optional values (`helpers/optional-value.ts`)
 

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -50,8 +50,9 @@ Run: `npm run lint` (root, lints the whole workspace via flat config) or `npm ru
    */
   ```
   New files must include this header. Update the year on substantive rewrites (existing files mix `2024`, `2025`, `2026`).
-- **Index barrels**: every directory under `src/` has an `index.ts` re-exporting its members. Keep this pattern when adding modules — `src/index.ts` re-exports each subdir wholesale.
+- **Index barrels**: every directory under `src/` has an `index.ts` re-exporting its members. Keep this pattern when adding modules — `src/index.ts` re-exports each subdir wholesale. Two modules are deliberately excluded because they are internal plumbing, not API: `container/run-sync-violation.ts` and `utils/twin.ts`. Don't "fix" them by adding a barrel line.
 - **Imports**: prefer `import type { ... }` for type-only imports. The codebase is consistent about this (see `container/module.ts`).
+- **Never hand-write a second sync/async loop.** `Container.run` / `runSync` derive from one twin body (`Container.runBody`, see [Architecture](architecture.md#the-syncasync-twin-body-runbody)). A new run option or mount option goes into the body plus `buildChildRunOptions` if children inherit it — and gets a case in `test/unit/run-parity.spec.ts`. `runParallel` is the one loop that stays separate (scheduling shape); it consumes the same per-key helpers, so most options need no edit there.
 
 ## Commit Messages
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -76,13 +76,13 @@ Build scripts per package:
 
 | Subdir       | Responsibility                                                                              |
 |--------------|---------------------------------------------------------------------------------------------|
-| `container/` | `Container` class (`module.ts`), `IContainer`/`Mount`/`MountOptions` types, `isContainer`. `ValidatorMount` gains a `sideEffect?: boolean` resolved from descriptor at mount time. `ContainerRunOptions` gains `cache?: IResultCache`. `ContainerOptions`/`ContainerRunOptions` gain `pathsStrict?: boolean`; `paths-strict-violation.ts` holds the exported `PathsStrictViolationError` + `isPathsStrictViolation` guard (run-sync's internal violation lives in `run-sync-violation.ts`) |
+| `container/` | `Container` class (`module.ts`), `IContainer`/`Mount`/`MountOptions` types, `isContainer`. `run` / `runSync` are thin drivers over one private generator, `runBody` — see [Architecture → the twin body](architecture.md#the-syncasync-twin-body-runbody); `runParallel` keeps its own scheduling loop but shares every per-key helper. `ValidatorMount` gains a `sideEffect?: boolean` resolved from descriptor at mount time. `ContainerRunOptions` gains `cache?: IResultCache`. `ContainerOptions`/`ContainerRunOptions` gain `pathsStrict?: boolean`; `paths-strict-violation.ts` holds the exported `PathsStrictViolationError` + `isPathsStrictViolation` guard (run-sync's internal violation lives in `run-sync-violation.ts`) |
 | `error/`     | `ValidupError` class (`base.ts`) and `isError`/`isValidupError` guards (`check.ts`)         |
 | `issue/`     | `Issue` types (item/group), `IssueCode` enum, `defineIssueItem`/`defineIssueGroup` factories, `isIssue`/`isIssueItem`/`isIssueGroup` guards, `flattenIssueItems`/`flattenIssueGroups` |
 | `validator/` | `ValidatorDescriptor<C, Out>` type, `defineValidator(descriptor)` factory, `isValidatorDescriptor` duck-typed guard. The wrap layer that lets a validator declare per-mount contract metadata (currently `sideEffect`) without mutating the function object |
 | `cache/`     | `IResultCache` interface, `ResultCache` class (Map-backed default impl), `ResultCacheSnapshot` / `ResultCacheOutcome` / `ResultCacheEntry` types, `isResultCache` duck-typed guard. Storage-only — equality + skip logic lives in `container/module.ts:resolveCachedOutcome` |
 | `helpers/`   | `buildErrorMessageForAttribute(s)`, `isOptionalValue`, `stringifyPath`, `resolveDefaults`, `resolvePathFilter` |
-| `utils/`     | Internal helpers — `isObject`, `hasOwnProperty`                                             |
+| `utils/`     | Internal helpers — `isObject`, `hasOwnProperty`. Plus `twin.ts` (`op` / `runTwinAsync` / `runTwinSync` — the sync/async twin protocol behind `Container.runBody`), deliberately **not** in `utils/index.ts` and therefore not public, same treatment as `container/run-sync-violation.ts` |
 | `constants.ts` | `GroupKey.WILDCARD = '*'`, `OptionalValue` enum (`UNDEFINED` / `NULL` / `FALSY`)          |
 | `types.ts`   | `Validator`, `ValidatorContext`, `ObjectLiteral`                                            |
 | `index.ts`   | Re-exports every subdir (barrel — preserve when adding modules)                             |
@@ -108,7 +108,8 @@ src/
 
 Tests live under each package in `test/` (not a top-level `tests/` dir):
 
-- `packages/validup/test/unit/*.spec.ts` — covers the core (module, group, mount-key, optional, one-of, paths-to-include, error, issue, initialize, define-validator, cache)
-- `packages/validup/test/data/` — shared fixtures (`string-validator.ts`)
+- `packages/validup/test/unit/*.spec.ts` — 26 specs covering the core (module, group, mount-key, optional, optional-value, path-filter, defaults, one-of, paths-to-include, paths-strict, error, error-to-issues, issue, format, initialize, define-validator, cache, compose, builder, parallel, run-sync, run-parity, twin, abort-signal, context, typing)
+- `packages/validup/test/data/` — shared fixtures (`string-validator.ts`, exporting both `stringValidator` (async) and `stringValidatorSync`)
+- `packages/validup/test/helpers/` — spec helpers, not collected by vitest (`parity.ts` — `expectRunParity` / `expectRunFailureParity`, the `run` ↔ `runSync` twin contract)
 - Integration packages each have their own `test/vitest.config.ts` and `test/unit/*.spec.ts`
 - `@validup/vue` uses `environment: 'happy-dom'` in its vitest config (the only package that needs a DOM); the others use the default Node env.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -13,10 +13,11 @@ packages/<pkg>/test/
 ├── vitest.config.ts
 ├── unit/
 │   └── *.spec.ts        # one spec per concern
-└── data/                # shared fixtures (validup core only)
+├── data/                # shared fixtures (validup core only)
+└── helpers/             # assertion helpers, not collected (validup core only)
 ```
 
-Spec discovery (`test.include`): `test/unit/**/*.{test,spec}.{js,ts}`. New specs should live under `test/unit/` and end in `.spec.ts`.
+Spec discovery (`test.include`): `test/unit/**/*.{test,spec}.{js,ts}`. New specs should live under `test/unit/` and end in `.spec.ts`. `test/data/` and `test/helpers/` sit outside that glob on purpose, so nothing in them is collected as a suite.
 
 Specs reach package source via relative imports — `import { Container } from '../../src';` from inside `test/unit/`.
 
@@ -46,8 +47,31 @@ Run with `npm run test:coverage` inside the package. CI does **not** fail on cov
 | `error.spec.ts`               | `ValidupError` shape and `isValidupError` guard           |
 | `issue.spec.ts`               | `Issue` factories and guards                              |
 | `initialize.spec.ts`          | Subclass `initialize()` hook                              |
+| `run-sync.spec.ts`            | `runSync` / `safeRunSync` + `RunSyncViolationError`       |
+| `parallel.spec.ts`            | `runParallel` scheduling and issue ordering               |
+| `run-parity.spec.ts`          | `run` ↔ `runSync` twin contract, table-driven             |
+| `twin.spec.ts`                | The `src/utils/twin.ts` protocol itself                   |
+| `optional-value.spec.ts`      | `isOptionalValue` atom matcher, at its own edge           |
+| `path-filter.spec.ts`         | `resolvePathFilter` include/exclude verdict               |
+| `defaults.spec.ts`            | `resolveDefaults` child-slice helper                      |
 
 When adding a new container option or mount option, add or extend the matching spec — don't pile new cases into `module.spec.ts`.
+
+### Sync/async parity
+
+`run` and `runSync` are two drivers over one shared body (`Container.runBody`), so a mount-resolution rule that holds for one must hold for the other. Assert that once via the helpers in `test/helpers/parity.ts` rather than hand-duplicating each `it()` per variant:
+
+```ts
+import { expectRunFailureParity, expectRunParity } from '../helpers/parity';
+
+// success: both variants run, outputs must be deeply equal
+const output = await expectRunParity(container, input, options);
+
+// failure: both variants must fail with deeply-equal issue trees
+const issues = await expectRunFailureParity(container, input, options);
+```
+
+Parity specs need **synchronous** validators — `runSync` rejects any thenable return. Use `stringValidatorSync` from `test/data`, not the async `stringValidator`.
 
 ## Writing Tests
 

--- a/docs/src/guide/run-modes.md
+++ b/docs/src/guide/run-modes.md
@@ -23,7 +23,9 @@ container.mount('name', isString);     // sees the trimmed value
 
 ## `runSync()`
 
-Same loop without `await`. Validator return values must not be thenable; nested containers must implement `runSync`. Violations throw a `RunSyncViolationError` (use the duck-type guard `isRunSyncViolation`) — these are **not** folded into the issue list, because they mean the caller can't use sync mode against this graph at all.
+Literally the same loop without `await` — `run()` and `runSync()` are two drivers over **one** shared mount-resolution body, not two implementations. Every mount option (groups, `optional` / `optionalValue` / `optionalAs`, path filters, `defaults`, `pathsStrict`, `cache`) resolves identically in both, including the sequential sibling chain-read above, so a sync run cannot silently drift from its async twin.
+
+Two things differ, both structural: validator return values must not be thenable, and nested containers must implement `runSync`. Violations throw a `RunSyncViolationError` (use the duck-type guard `isRunSyncViolation`) — these are **not** folded into the issue list, because they mean the caller can't use sync mode against this graph at all.
 
 ```typescript
 const out = container.runSync(input); // throws on async validator

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -649,6 +649,8 @@ const out = container.runSync(input);  // returns T directly, not Promise<T>
 
 `runSync()` throws synchronously if a validator returns a Promise or if a nested container does not implement `runSync` — those are *structural* failures (not validation outcomes), so they're surfaced verbatim and never wrapped into `Result.failure` by `safeRunSync`. Use the async `run()` for any graph that mixes sync and async validators.
 
+`run()` and `runSync()` are **not two implementations**. Both drive one shared mount-resolution body, so every mount option (groups, `optional` / `optionalValue` / `optionalAs`, path filters, `defaults`, `pathsStrict`, `cache`) resolves identically in both — a sync run can't silently drift from its async twin. The only differences are the two structural probes above.
+
 ## Localized Messages
 
 `Issue.message` is rendered eagerly in English at construction time. For i18n / custom locales, every issue also carries a structured `data?: Record<string, unknown>` field (populated by the runtime where the message references a non-trivial value — e.g. `{ name: 'email' }` on the wrapping group at a failing mount). Pair it with `formatIssue` and a `code → template` map to render at the consumer side:

--- a/packages/validup/src/container/module.ts
+++ b/packages/validup/src/container/module.ts
@@ -19,6 +19,7 @@ import type {
 } from '../cache';
 import { GroupKey } from '../constants';
 import { ValidupError, isError, isValidupError } from '../error';
+import type { PathFilterResolution } from '../helpers';
 import {
     buildErrorMessageForAttribute,
     buildOneOfFailedGroup,
@@ -28,7 +29,13 @@ import {
     stringifyPath,
 } from '../helpers';
 import { hasOwnProperty, isObject } from '../utils';
-import type { Validator, ValidatorDescriptor } from '../validator';
+import type { TwinBody } from '../utils/twin';
+import { op, runTwinAsync, runTwinSync } from '../utils/twin';
+import type {
+    Validator,
+    ValidatorContext,
+    ValidatorDescriptor,
+} from '../validator';
 import { isValidatorDescriptor } from '../validator';
 import { isContainer } from './check';
 import type {
@@ -70,6 +77,56 @@ type ExecutionFailureContext<C> = {
     /** Per-run abort signal. If aborted, the throw is re-raised verbatim. */
     signal: AbortSignal | undefined,
 };
+
+/**
+ * Everything a single `(mount, expanded key)` pair needs before the mount can
+ * be dispatched. Produced once per key by `Container.prepareMountKey` and
+ * consumed identically by the twin body and by `runParallel`.
+ *
+ * Notably absent: the mount's input `value`. Sequential runs chain-read
+ * `output` before `data` (so sanitize-then-validate works across sibling
+ * mounts) while `runParallel` reads `data` only — that asymmetry is a
+ * documented behavioural difference, so it stays in the caller and this stays
+ * pure.
+ */
+type MountKeyPlan = {
+    /** Expanded key split into segments. Prefixed onto child issue paths. */
+    keyParts: PropertyKey[],
+    /** Trailing segment. Drives the wrapping `IssueGroup` shape on failure. */
+    pathRelative: PropertyKey | undefined,
+    /** Global path (parent prefix + `keyParts`) handed to validators/children. */
+    pathAbsolute: PropertyKey[],
+    /** Include/exclude verdict plus the sub-lists to forward to a child. */
+    filter: PathFilterResolution,
+};
+
+/**
+ * Outcome of the optional gate for one `(mount, value)` pair.
+ *
+ * - `skip: false` — the mount runs normally.
+ * - `skip: true, write: true` — the mount is skipped and `value` is assigned
+ *   to `output[key]`.
+ * - `skip: true, write: false` — the mount is skipped and the key is omitted.
+ *
+ * `write` is what carries the presence-not-value semantics of `optionalAs`:
+ * `{ skip: true, write: true, value: undefined }` is the deliberate "emit
+ * `undefined`" directive, distinct from "omit the key".
+ */
+type OptionalDirective = {
+    skip: boolean,
+    write: boolean,
+    value?: unknown,
+};
+
+/**
+ * Structural thenable probe. Used by the sync side of the validator effect to
+ * reject the one thing a synchronous graph cannot tolerate: a validator that
+ * returned a promise.
+ */
+function isThenable(input: unknown): input is PromiseLike<unknown> {
+    return isObject(input) &&
+        typeof (input as { then?: unknown }).then === 'function';
+}
 
 export class Container<
     T extends Record<string, any> = Record<string, any>,
@@ -259,15 +316,45 @@ export class Container<
         data: ContainerInput<T> = {},
         options: ContainerRunOptions<T, C> = {},
     ): Promise<T> {
-        const { pathsToInclude, pathsToExclude } = this.resolveContainerFilters(options);
-        const pathsStrict = this.resolvePathsStrict(options);
-        // Structural pre-flight — throws before any validator runs, covering
-        // both the sequential loop below and the delegated parallel run.
-        this.assertPathsStrict(pathsStrict, data, pathsToInclude, pathsToExclude, options.path);
-
         if (options.parallel) {
             return this.runParallel(data, options);
         }
+
+        return runTwinAsync(this.runBody(data, options));
+    }
+
+    /**
+     * The single mount-resolution loop behind {@link Container.run} and
+     * {@link Container.runSync}.
+     *
+     * Written as a **twin body** (`src/utils/twin.ts`): the two impure edges —
+     * invoking a validator and descending into a nested container — are yielded
+     * as `op(asyncThunk, syncThunk)` pairs, and the driver chosen by the public
+     * method (`runTwinAsync` / `runTwinSync`) executes the matching side. Effect
+     * errors are thrown back in at the `yield` site, so the cache-write and
+     * issue-collection `try`/`catch` blocks below run identically in both
+     * variants — no second copy of the loop to keep in lockstep.
+     *
+     * The sync thunks own the two structural probes that only `runSync` needs:
+     * a nested container that doesn't implement `runSync`, and a validator that
+     * returned a thenable. Both throw `RunSyncViolationError`, which the async
+     * side cannot produce.
+     *
+     * `runParallel` deliberately does NOT share this body — a generator is
+     * sequential by construction, and expressing "launch every mount, then
+     * settle" through it would mean yielding batches and giving up the
+     * chain-read. It shares the extracted per-key helpers instead
+     * (`prepareMountKey` / `resolveOptionalDirective` / `buildChildRunOptions` /
+     * `buildValidatorContext`).
+     */
+    private * runBody(
+        data: ContainerInput<T>,
+        options: ContainerRunOptions<T, C>,
+    ): TwinBody<T> {
+        const { pathsToInclude, pathsToExclude } = this.resolveContainerFilters(options);
+        const pathsStrict = this.resolvePathsStrict(options);
+        // Structural pre-flight — throws before any validator runs.
+        this.assertPathsStrict(pathsStrict, data, pathsToInclude, pathsToExclude, options.path);
 
         const output: Record<string, any> = {};
         const issues: Issue[] = [];
@@ -294,13 +381,7 @@ export class Container<
             const keys: string[] = item.path ? expandPath(data, item.path) : [''];
 
             for (const key of keys) {
-                const keyParts = key ? pathToArray(key) : [];
-
-                const pathRelative = keyParts.at(-1);
-                const pathAbsolute = [
-                    ...(options.path ? options.path : []),
-                    ...keyParts,
-                ];
+                const plan = this.prepareMountKey(item, key, options, pathsToInclude, pathsToExclude);
 
                 let value: unknown;
                 if (key.length > 0) {
@@ -311,58 +392,35 @@ export class Container<
                     value = data;
                 }
 
-                const filter = resolvePathFilter(
-                    pathsToInclude,
-                    pathsToExclude,
-                    key,
-                    item.type === 'container',
-                );
-                if (filter.skip) {
+                if (plan.filter.skip) {
                     continue;
                 }
 
                 try {
-                    const resolvedOptionalValue = item.options.optionalValue ??
-                        options.optionalValue ??
-                        this.options.optionalValue;
-                    const isOptional = typeof item.options.optional === 'function' ?
-                        item.options.optional(value) :
-                        item.options.optional &&
-                            isOptionalValue(value, resolvedOptionalValue);
+                    const optional = this.resolveOptionalDirective(item, value, options);
 
-                    if (isOptional) {
-                        if (hasOwnProperty(item.options, 'optionalAs')) {
-                            output[key] = item.options.optionalAs;
-                        } else if (hasOwnProperty(options, 'optionalAs')) {
-                            output[key] = options.optionalAs;
-                        } else if (hasOwnProperty(this.options, 'optionalAs')) {
-                            output[key] = this.options.optionalAs;
-                        } else if (item.options.optionalInclude) {
-                            output[key] = value;
+                    if (optional.skip) {
+                        if (optional.write) {
+                            output[key] = optional.value;
                         }
                     } else if (item.type === 'container') {
-                        const tmp = await item.data.run(
-                            isObject(value) ? value : {},
-                            {
-                                group: options.group,
-                                flat: true,
-                                path: pathAbsolute,
-                                pathsToInclude: filter.pathsToInclude,
-                                pathsToExclude: filter.pathsToExclude,
-                                // Not forwarded into keyless (`key === ''`)
-                                // children: they share the parent namespace and
-                                // receive the filter list verbatim, so strict
-                                // there would throw for paths owned by the
-                                // parent's own sibling mounts. Keyless subtrees
-                                // are a deliberate strict blind spot.
-                                ...(pathsStrict && key.length > 0 ? { pathsStrict: true } : {}),
-                                defaults: resolveDefaults(options.defaults, key),
-                                context: options.context,
-                                signal: options.signal,
-                                cache: options.cache,
-                                optionalValue: options.optionalValue,
-                                ...(hasOwnProperty(options, 'optionalAs') ?
-                                    { optionalAs: options.optionalAs } : {}),
+                        const child = item.data;
+                        const childInput = isObject(value) ? value : {};
+                        const childOptions = this.buildChildRunOptions(options, key, plan, pathsStrict);
+
+                        const tmp: Record<string, any> = yield* op(
+                            () => child.run(childInput, childOptions),
+                            () => {
+                                const childRunSync = (
+                                    child as IContainer<any, any> & {
+                                        runSync?: (...args: any[]) => any
+                                    }
+                                ).runSync;
+                                if (typeof childRunSync !== 'function') {
+                                    throw new RunSyncViolationError(`runSync: nested container at "${key || '<root>'}" does not implement runSync`);
+                                }
+
+                                return childRunSync.call(child, childInput, childOptions);
                             },
                         );
 
@@ -389,18 +447,20 @@ export class Container<
                                 throw cached.error;
                             }
                         } else {
-                            try {
-                                const result = await item.data({
-                                    key,
-                                    path: pathAbsolute,
+                            const validator = item.data;
+                            const ctx = this.buildValidatorContext(key, plan, value, data, options);
 
-                                    value,
-                                    data,
-                                    group: options.group,
-                                    context: options.context as C,
-                                    signal: options.signal,
-                                    cache: options.cache,
-                                });
+                            try {
+                                const result = yield* op(
+                                    () => validator(ctx),
+                                    () => {
+                                        const outcome = validator(ctx);
+                                        if (isThenable(outcome)) {
+                                            throw new RunSyncViolationError(`runSync: validator at "${key || '<root>'}" returned a Promise`);
+                                        }
+                                        return outcome;
+                                    },
+                                );
                                 output[key] = result;
                                 this.writeCachedOutcome(
                                     item,
@@ -411,14 +471,22 @@ export class Container<
                                     options.signal,
                                 );
                             } catch (e) {
-                                this.writeCachedOutcome(
-                                    item,
-                                    key,
-                                    snapshot,
-                                    { ok: false, error: e },
-                                    options.cache,
-                                    options.signal,
-                                );
+                                // RunSyncViolation is structural — don't pollute the
+                                // cache with a graph-level error that the next run
+                                // might reach through different mounts. Only the sync
+                                // side can raise one from the effect above; guarding
+                                // unconditionally also covers the pathological case
+                                // of an async validator letting one escape.
+                                if (!isRunSyncViolation(e)) {
+                                    this.writeCachedOutcome(
+                                        item,
+                                        key,
+                                        snapshot,
+                                        { ok: false, error: e },
+                                        options.cache,
+                                        options.signal,
+                                    );
+                                }
                                 throw e;
                             }
                         }
@@ -428,8 +496,8 @@ export class Container<
                         error: e,
                         item,
                         value,
-                        keyParts,
-                        pathRelative,
+                        keyParts: plan.keyParts,
+                        pathRelative: plan.pathRelative,
                         issues,
                         signal: options.signal,
                     });
@@ -456,15 +524,21 @@ export class Container<
      * Parallel-execution variant of `run()`. All mounts kick off their
      * promises eagerly and the results are merged after `Promise.allSettled`.
      * See `ContainerRunOptions.parallel` for the trade-off note.
+     *
+     * Shares every per-key helper with the sequential twin body
+     * (`prepareMountKey` / `resolveOptionalDirective` / `buildChildRunOptions` /
+     * `buildValidatorContext` / the cache pair) but keeps its own scheduling
+     * loop — see the note on {@link Container.runBody} for why it can't be a
+     * third twin driver.
      */
     private async runParallel(
         data: ContainerInput<T>,
         options: ContainerRunOptions<T, C>,
     ): Promise<T> {
         const { pathsToInclude, pathsToExclude } = this.resolveContainerFilters(options);
-        // Strict pre-flight already ran in `run()` before it delegated here;
-        // this container only needs the resolved flag to forward downward.
         const pathsStrict = this.resolvePathsStrict(options);
+        // Structural pre-flight — throws before any mount's promise is created.
+        this.assertPathsStrict(pathsStrict, data, pathsToInclude, pathsToExclude, options.path);
 
         const output: Record<string, any> = {};
         const issues: Issue[] = [];
@@ -509,12 +583,7 @@ export class Container<
 
             const keys: string[] = item.path ? expandPath(data, item.path) : [''];
             for (const key of keys) {
-                const keyParts = key ? pathToArray(key) : [];
-                const pathRelative = keyParts.at(-1);
-                const pathAbsolute = [
-                    ...(options.path ? options.path : []),
-                    ...keyParts,
-                ];
+                const plan = this.prepareMountKey(item, key, options, pathsToInclude, pathsToExclude);
 
                 let value: unknown;
                 if (key.length > 0) {
@@ -526,33 +595,14 @@ export class Container<
                     value = data;
                 }
 
-                const filter = resolvePathFilter(
-                    pathsToInclude,
-                    pathsToExclude,
-                    key,
-                    item.type === 'container',
-                );
-                if (filter.skip) {
+                if (plan.filter.skip) {
                     continue;
                 }
 
-                const resolvedOptionalValue = item.options.optionalValue ??
-                    options.optionalValue ??
-                    this.options.optionalValue;
-                const isOptional = typeof item.options.optional === 'function' ?
-                    item.options.optional(value) :
-                    item.options.optional &&
-                        isOptionalValue(value, resolvedOptionalValue);
-
-                if (isOptional) {
-                    if (hasOwnProperty(item.options, 'optionalAs')) {
-                        output[key] = item.options.optionalAs;
-                    } else if (hasOwnProperty(options, 'optionalAs')) {
-                        output[key] = options.optionalAs;
-                    } else if (hasOwnProperty(this.options, 'optionalAs')) {
-                        output[key] = this.options.optionalAs;
-                    } else if (item.options.optionalInclude) {
-                        output[key] = value;
+                const optional = this.resolveOptionalDirective(item, value, options);
+                if (optional.skip) {
+                    if (optional.write) {
+                        output[key] = optional.value;
                     }
                     syncPathCount++;
                     continue;
@@ -562,24 +612,7 @@ export class Container<
                 if (item.type === 'container') {
                     promise = item.data.run(
                         isObject(value) ? value : {},
-                        {
-                            group: options.group,
-                            flat: true,
-                            path: pathAbsolute,
-                            pathsToInclude: filter.pathsToInclude,
-                            pathsToExclude: filter.pathsToExclude,
-                            // Keyless children are a strict blind spot — see
-                            // the note at the sequential `run()` forward site.
-                            ...(pathsStrict && key.length > 0 ? { pathsStrict: true } : {}),
-                            defaults: resolveDefaults(options.defaults, key),
-                            context: options.context,
-                            signal: options.signal,
-                            parallel: true,
-                            cache: options.cache,
-                            optionalValue: options.optionalValue,
-                            ...(hasOwnProperty(options, 'optionalAs') ?
-                                { optionalAs: options.optionalAs } : {}),
-                        },
+                        this.buildChildRunOptions(options, key, plan, pathsStrict, true),
                     );
                 } else {
                     const snapshot: ResultCacheSnapshot = {
@@ -601,22 +634,14 @@ export class Container<
                         // `Promise.allSettled` always sees a thenable. Cache
                         // writes happen inside the wrapper so the entry is
                         // persisted before the promise settles.
-                        const itemData = item.data;
+                        const validator = item.data;
+                        const ctx = this.buildValidatorContext(key, plan, value, data, options);
                         const captureItem = item;
                         const captureKey = key;
                         const captureSnapshot = snapshot;
                         promise = (async () => {
                             try {
-                                const result = await itemData({
-                                    key,
-                                    path: pathAbsolute,
-                                    value,
-                                    data,
-                                    group: options.group,
-                                    context: options.context as C,
-                                    signal: options.signal,
-                                    cache: options.cache,
-                                });
+                                const result = await validator(ctx);
                                 this.writeCachedOutcome(
                                     captureItem,
                                     captureKey,
@@ -643,8 +668,8 @@ export class Container<
 
                 tasks.push({
                     key,
-                    keyParts,
-                    pathRelative,
+                    keyParts: plan.keyParts,
+                    pathRelative: plan.pathRelative,
                     value,
                     promise,
                     kind: item.type,
@@ -776,199 +801,7 @@ export class Container<
         data: ContainerInput<T> = {},
         options: ContainerRunOptions<T, C> = {},
     ): T {
-        const { pathsToInclude, pathsToExclude } = this.resolveContainerFilters(options);
-        const pathsStrict = this.resolvePathsStrict(options);
-        this.assertPathsStrict(pathsStrict, data, pathsToInclude, pathsToExclude, options.path);
-
-        const output: Record<string, any> = {};
-        const issues: Issue[] = [];
-
-        let itemCount = 0;
-        let errorCount = 0;
-
-        for (let i = 0; i < this.items.length; i++) {
-            options.signal?.throwIfAborted();
-
-            const item = this.items[i];
-
-            if (!this.isItemGroupIncluded(item, options.group)) {
-                continue;
-            }
-
-            let pathCount = 0;
-            let pathFailed = false;
-            const branchStart = issues.length;
-
-            const keys: string[] = item.path ? expandPath(data, item.path) : [''];
-
-            for (const key of keys) {
-                const keyParts = key ? pathToArray(key) : [];
-
-                const pathRelative = keyParts.at(-1);
-                const pathAbsolute = [
-                    ...(options.path ? options.path : []),
-                    ...keyParts,
-                ];
-
-                let value: unknown;
-                if (key.length > 0) {
-                    value = hasOwnProperty(output, key) ?
-                        output[key] :
-                        getPathValue(data, key);
-                } else {
-                    value = data;
-                }
-
-                const filter = resolvePathFilter(
-                    pathsToInclude,
-                    pathsToExclude,
-                    key,
-                    item.type === 'container',
-                );
-                if (filter.skip) {
-                    continue;
-                }
-
-                try {
-                    const resolvedOptionalValue = item.options.optionalValue ??
-                        options.optionalValue ??
-                        this.options.optionalValue;
-                    const isOptional = typeof item.options.optional === 'function' ?
-                        item.options.optional(value) :
-                        item.options.optional &&
-                            isOptionalValue(value, resolvedOptionalValue);
-
-                    if (isOptional) {
-                        if (hasOwnProperty(item.options, 'optionalAs')) {
-                            output[key] = item.options.optionalAs;
-                        } else if (hasOwnProperty(options, 'optionalAs')) {
-                            output[key] = options.optionalAs;
-                        } else if (hasOwnProperty(this.options, 'optionalAs')) {
-                            output[key] = this.options.optionalAs;
-                        } else if (item.options.optionalInclude) {
-                            output[key] = value;
-                        }
-                    } else if (item.type === 'container') {
-                        const childRunSync = (
-                            item.data as IContainer<any, any> & {
-                                runSync?: (...args: any[]) => any
-                            }
-                        ).runSync;
-                        if (typeof childRunSync !== 'function') {
-                            throw new RunSyncViolationError(`runSync: nested container at "${key || '<root>'}" does not implement runSync`);
-                        }
-
-                        const tmp = childRunSync.call(item.data, isObject(value) ? value : {}, {
-                            group: options.group,
-                            flat: true,
-                            path: pathAbsolute,
-                            pathsToInclude: filter.pathsToInclude,
-                            pathsToExclude: filter.pathsToExclude,
-                            // Keyless children are a strict blind spot — see
-                            // the note at the sequential `run()` forward site.
-                            ...(pathsStrict && key.length > 0 ? { pathsStrict: true } : {}),
-                            defaults: resolveDefaults(options.defaults, key),
-                            context: options.context,
-                            signal: options.signal,
-                            cache: options.cache,
-                            optionalValue: options.optionalValue,
-                            ...(hasOwnProperty(options, 'optionalAs') ?
-                                { optionalAs: options.optionalAs } : {}),
-                        });
-
-                        const tmpKeys = Object.keys(tmp);
-                        for (const tmpKey of tmpKeys) {
-                            output[this.mergePaths(key, tmpKey)] = tmp[tmpKey];
-                        }
-                    } else if (item.type === 'validator') {
-                        const snapshot: ResultCacheSnapshot = {
-                            value,
-                            context: options.context,
-                            group: options.group,
-                        };
-                        const cached = this.resolveCachedOutcome(item, key, snapshot, options.cache);
-                        if (cached) {
-                            if (cached.ok) {
-                                output[key] = cached.value;
-                            } else {
-                                throw cached.error;
-                            }
-                        } else {
-                            try {
-                                const result = item.data({
-                                    key,
-                                    path: pathAbsolute,
-
-                                    value,
-                                    data,
-                                    group: options.group,
-                                    context: options.context as C,
-                                    signal: options.signal,
-                                    cache: options.cache,
-                                });
-                                if (
-                                    result !== null &&
-                                    typeof result === 'object' &&
-                                    typeof (result as { then?: unknown }).then === 'function'
-                                ) {
-                                    // Don't cache: structural violation, not a
-                                    // validation outcome.
-                                    throw new RunSyncViolationError(`runSync: validator at "${key || '<root>'}" returned a Promise`);
-                                }
-                                output[key] = result;
-                                this.writeCachedOutcome(
-                                    item,
-                                    key,
-                                    snapshot,
-                                    { ok: true, value: result },
-                                    options.cache,
-                                    options.signal,
-                                );
-                            } catch (e) {
-                                // RunSyncViolation is structural — don't pollute
-                                // the cache with a graph-level error that the
-                                // next run might reach through different mounts.
-                                if (!isRunSyncViolation(e)) {
-                                    this.writeCachedOutcome(
-                                        item,
-                                        key,
-                                        snapshot,
-                                        { ok: false, error: e },
-                                        options.cache,
-                                        options.signal,
-                                    );
-                                }
-                                throw e;
-                            }
-                        }
-                    }
-                } catch (e) {
-                    this.collectExecutionFailure({
-                        error: e,
-                        item,
-                        value,
-                        keyParts,
-                        pathRelative,
-                        issues,
-                        signal: options.signal,
-                    });
-                    pathFailed = true;
-                }
-
-                pathCount++;
-            }
-
-            if (pathCount > 0) {
-                itemCount++;
-
-                if (pathFailed) {
-                    errorCount++;
-                    this.wrapBranchForOneOf(issues, branchStart, item, i);
-                }
-            }
-        }
-
-        return this.finalizeOutput(output, options, issues, errorCount, itemCount);
+        return runTwinSync(this.runBody(data, options));
     }
 
     safeRunSync(input: ContainerInput<T> = {}, options: ContainerRunOptions<T, C> = {}): Result<T> {
@@ -978,6 +811,151 @@ export class Container<
         } catch (e) {
             return this.wrapSafeRunError(e, options);
         }
+    }
+
+    /**
+     * Resolve everything a single `(mount, expanded key)` pair needs before
+     * dispatch: the split path parts, the absolute path handed to validators
+     * and child containers, and the include/exclude verdict.
+     *
+     * Shared verbatim by the twin body and `runParallel`. The mount's input
+     * `value` is deliberately NOT read here — see {@link MountKeyPlan}.
+     */
+    private prepareMountKey(
+        item: Mount<C>,
+        key: string,
+        options: ContainerRunOptions<T, C>,
+        pathsToInclude: string[] | undefined,
+        pathsToExclude: string[] | undefined,
+    ): MountKeyPlan {
+        const keyParts = key ? pathToArray(key) : [];
+
+        return {
+            keyParts,
+            pathRelative: keyParts.at(-1),
+            pathAbsolute: [
+                ...(options.path ? options.path : []),
+                ...keyParts,
+            ],
+            filter: resolvePathFilter(
+                pathsToInclude,
+                pathsToExclude,
+                key,
+                item.type === 'container',
+            ),
+        };
+    }
+
+    /**
+     * Resolve the optional gate and — when it fires — what (if anything) the
+     * skipped key contributes to the output.
+     *
+     * `optional` is the gate ("may this mount be skipped?"); `optionalValue` is
+     * the definition of absent, resolved mount → run → container. A predicate
+     * `optional` wins over the atom vocabulary entirely.
+     *
+     * The write directive follows the same three layers, but keys off
+     * `optionalAs` **presence** rather than its value — `{ optionalAs:
+     * undefined }` at any layer is a deliberate "emit `undefined`". Only when
+     * no layer declares `optionalAs` does the mount-level `optionalInclude`
+     * fallback (copy the input through) apply.
+     */
+    private resolveOptionalDirective(
+        item: Mount<C>,
+        value: unknown,
+        options: ContainerRunOptions<T, C>,
+    ): OptionalDirective {
+        const resolvedOptionalValue = item.options.optionalValue ??
+            options.optionalValue ??
+            this.options.optionalValue;
+        const isOptional = typeof item.options.optional === 'function' ?
+            item.options.optional(value) :
+            item.options.optional &&
+                isOptionalValue(value, resolvedOptionalValue);
+
+        if (!isOptional) {
+            return { skip: false, write: false };
+        }
+
+        let write = true;
+        let writeValue: unknown;
+        if (hasOwnProperty(item.options, 'optionalAs')) {
+            writeValue = item.options.optionalAs;
+        } else if (hasOwnProperty(options, 'optionalAs')) {
+            writeValue = options.optionalAs;
+        } else if (hasOwnProperty(this.options, 'optionalAs')) {
+            writeValue = this.options.optionalAs;
+        } else if (item.options.optionalInclude) {
+            writeValue = value;
+        } else {
+            write = false;
+        }
+
+        return {
+            skip: true,
+            write,
+            value: writeValue,
+        };
+    }
+
+    /**
+     * Build the option bag forwarded into a nested container's `run` /
+     * `runSync`. Single source of truth for what a child inherits, so a new
+     * run option is threaded downward in one place instead of three.
+     */
+    private buildChildRunOptions(
+        options: ContainerRunOptions<T, C>,
+        key: string,
+        plan: MountKeyPlan,
+        pathsStrict: boolean,
+        parallel = false,
+    ): ContainerRunOptions<any, C> {
+        return {
+            group: options.group,
+            flat: true,
+            path: plan.pathAbsolute,
+            pathsToInclude: plan.filter.pathsToInclude,
+            pathsToExclude: plan.filter.pathsToExclude,
+            // Not forwarded into keyless (`key === ''`) children: they share
+            // the parent namespace and receive the filter list verbatim, so
+            // strict there would throw for paths owned by the parent's own
+            // sibling mounts. Keyless subtrees are a deliberate strict blind
+            // spot.
+            ...(pathsStrict && key.length > 0 ? { pathsStrict: true } : {}),
+            defaults: resolveDefaults(options.defaults, key),
+            context: options.context,
+            signal: options.signal,
+            cache: options.cache,
+            ...(parallel ? { parallel: true } : {}),
+            optionalValue: options.optionalValue,
+            // Presence, not value — see `resolveOptionalDirective`. The child
+            // must see the layer's intent (emit-undefined vs. not-set) verbatim.
+            ...(hasOwnProperty(options, 'optionalAs') ?
+                { optionalAs: options.optionalAs } : {}),
+        };
+    }
+
+    /**
+     * Build the context object handed to a mounted validator.
+     */
+    private buildValidatorContext(
+        key: string,
+        plan: MountKeyPlan,
+        value: unknown,
+        data: ContainerInput<T>,
+        options: ContainerRunOptions<T, C>,
+    ): ValidatorContext<C> {
+        return {
+            key,
+            path: plan.pathAbsolute,
+
+            value,
+            data: data as Record<string, any>,
+            group: options.group,
+            context: options.context as C,
+            signal: options.signal,
+            cache: options.cache,
+        };
     }
 
     /**

--- a/packages/validup/src/utils/twin.ts
+++ b/packages/validup/src/utils/twin.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Internal protocol to derive parallel sync + async surfaces from **one**
+ * shared body. A body is a generator that yields effect pairs — an async and
+ * a sync thunk for the same operation — and the two drivers (`runTwinAsync` /
+ * `runTwinSync`) execute the side they stand for. Effect errors are re-entered
+ * into the body via `Generator.throw`, so `try`/`catch` around a `yield*` site
+ * behaves identically in both variants.
+ *
+ * Bodies compose via `yield*` delegation, so a body can call another body
+ * without either one knowing which side it will be driven on.
+ *
+ * Ported from `tada5hi/locter` (`src/utils/twin.ts`), with one deviation: the
+ * async thunk may return a bare value as well as a promise. Validup's async
+ * edge is a caller-supplied `Validator`, which is free to be synchronous —
+ * `runTwinAsync` awaits either shape.
+ *
+ * Deliberately NOT exported from the utils barrel (and therefore not from
+ * `src/index.ts`) — this is internal plumbing, not public API. Same treatment
+ * as `container/run-sync-violation.ts`.
+ */
+
+export type TwinOp<T = unknown> = {
+    async: () => T | Promise<T>,
+    sync: () => T,
+};
+
+export type TwinBody<R> = Generator<TwinOp<any>, R, any>;
+
+/**
+ * Perform one effect inside a twin body: `const x = yield* op(asyncFn, syncFn)`.
+ */
+export function* op<T>(
+    asyncFn: () => T | Promise<T>,
+    syncFn: () => T,
+) : Generator<TwinOp<T>, T, T> {
+    return yield { async: asyncFn, sync: syncFn };
+}
+
+/**
+ * Drive a twin body's async side. Each yielded op's `async` thunk is awaited;
+ * a rejection is thrown back into the body at the `yield` site so in-body
+ * `try`/`catch`/`finally` runs exactly as written.
+ */
+export async function runTwinAsync<R>(body: TwinBody<R>) : Promise<R> {
+    let step = body.next();
+    while (!step.done) {
+        let result : unknown;
+        try {
+            result = await step.value.async();
+        } catch (e) {
+            step = body.throw(e);
+            continue;
+        }
+
+        step = body.next(result);
+    }
+
+    return step.value;
+}
+
+/**
+ * Drive a twin body's sync side. Mirror of {@link runTwinAsync} with the
+ * `sync` thunk called directly — no microtask is introduced anywhere, which
+ * is the whole point of the synchronous surface.
+ */
+export function runTwinSync<R>(body: TwinBody<R>) : R {
+    let step = body.next();
+    while (!step.done) {
+        let result : unknown;
+        try {
+            result = step.value.sync();
+        } catch (e) {
+            step = body.throw(e);
+            continue;
+        }
+
+        step = body.next(result);
+    }
+
+    return step.value;
+}

--- a/packages/validup/test/data/string-validator.ts
+++ b/packages/validup/test/data/string-validator.ts
@@ -15,6 +15,20 @@ const stringValidator : Validator = async (ctx) : Promise<unknown> => {
     return ctx.value;
 };
 
+/**
+ * Synchronous twin of {@link stringValidator}. Required by specs that drive the
+ * same container through `run` *and* `runSync` (e.g. `run-parity.spec.ts`) —
+ * `runSync` rejects any validator that returns a thenable.
+ */
+const stringValidatorSync : Validator = (ctx) : unknown => {
+    if (typeof ctx.value !== 'string') {
+        throw new Error('Value is not a string');
+    }
+
+    return ctx.value;
+};
+
 export {
     stringValidator,
+    stringValidatorSync,
 };

--- a/packages/validup/test/helpers/parity.ts
+++ b/packages/validup/test/helpers/parity.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { expect } from 'vitest';
+import type { Container, ContainerInput, ContainerRunOptions } from '../../src';
+import { isValidupError } from '../../src';
+
+/**
+ * Assert the sync/async twin contract at the `Container` boundary: `run` and
+ * `runSync` are driven from one shared body (`Container.runBody`), so for any
+ * synchronous validator graph they must produce identical output — and, on
+ * failure, identical issue trees.
+ *
+ * Returns the async result so a caller can make further assertions on it.
+ */
+export async function expectRunParity<T extends Record<string, any>, C>(
+    container: Container<T, C>,
+    input?: ContainerInput<T>,
+    options?: ContainerRunOptions<T, C>,
+): Promise<T> {
+    const result = await container.run(input, options);
+    const resultSync = container.runSync(input, options);
+
+    expect(resultSync).toEqual(result);
+
+    return result;
+}
+
+/**
+ * Failure counterpart of {@link expectRunParity}: both variants must reject /
+ * throw, and the resulting `ValidupError.issues` trees must be deeply equal.
+ *
+ * Returns the async variant's issues for further assertions.
+ */
+export async function expectRunFailureParity<T extends Record<string, any>, C>(
+    container: Container<T, C>,
+    input?: ContainerInput<T>,
+    options?: ContainerRunOptions<T, C>,
+): Promise<unknown[]> {
+    const async = await container.safeRun(input, options);
+    const sync = container.safeRunSync(input, options);
+
+    expect(async.success).toEqual(false);
+    expect(sync.success).toEqual(false);
+
+    if (async.success || sync.success) {
+        throw new Error('expected both run variants to fail');
+    }
+
+    expect(isValidupError(async.error)).toEqual(true);
+    expect(sync.error.issues).toEqual(async.error.issues);
+
+    return async.error.issues;
+}

--- a/packages/validup/test/unit/defaults.spec.ts
+++ b/packages/validup/test/unit/defaults.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveDefaults } from '../../src';
+
+/**
+ * `resolveDefaults` slices a parent `defaults` map for one nested container
+ * mount. Consulted by the run loops through
+ * `Container.buildChildRunOptions`; asserted here at its own edge.
+ */
+describe('resolveDefaults', () => {
+    it('should return undefined when no defaults are supplied', () => {
+        expect(resolveDefaults(undefined, 'address')).toBeUndefined();
+    });
+
+    it('should forward the whole map for a keyless mount', () => {
+        const defaults = { 'a.b': 1, c: 2 };
+        expect(resolveDefaults(defaults, '')).toEqual(defaults);
+    });
+
+    it('should strip the mount prefix from matching entries', () => {
+        expect(resolveDefaults({ 'address.zip': '10115', name: 'Peter' }, 'address'))
+            .toEqual({ zip: '10115' });
+    });
+
+    it('should keep deeper paths intact below the stripped prefix', () => {
+        expect(resolveDefaults({ 'address.geo.lat': 52 }, 'address'))
+            .toEqual({ 'geo.lat': 52 });
+    });
+
+    it('should skip an exact-key match — the parent fills that in post-loop', () => {
+        expect(resolveDefaults({ address: {} }, 'address')).toBeUndefined();
+    });
+
+    it('should return undefined when nothing targets the mount', () => {
+        expect(resolveDefaults({ name: 'Peter' }, 'address')).toBeUndefined();
+    });
+
+    it('should not treat a shared name prefix as a match', () => {
+        expect(resolveDefaults({ 'addressLine.zip': 1 }, 'address')).toBeUndefined();
+    });
+
+    it('should preserve an undefined default value while reporting a match', () => {
+        expect(resolveDefaults({ 'address.zip': undefined }, 'address'))
+            .toEqual({ zip: undefined });
+    });
+});

--- a/packages/validup/test/unit/optional-value.spec.ts
+++ b/packages/validup/test/unit/optional-value.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { OptionalValue, isOptionalValue } from '../../src';
+
+/**
+ * `isOptionalValue` is the atom matcher the three run loops consult via
+ * `Container.resolveOptionalDirective`. Asserted here at its own edge —
+ * `optional.spec.ts` covers how the container *uses* it.
+ */
+describe('isOptionalValue', () => {
+    const values: Record<string, unknown> = {
+        undefined,
+        null: null,
+        emptyString: '',
+        zero: 0,
+        false: false,
+        nan: Number.NaN,
+        string: 'x',
+        one: 1,
+        true: true,
+        object: {},
+    };
+
+    const table: [`${OptionalValue}`, string[]][] = [
+        [OptionalValue.UNDEFINED, ['undefined']],
+        [OptionalValue.NULL, ['null']],
+        [OptionalValue.EMPTY_STRING, ['emptyString']],
+        [OptionalValue.ZERO, ['zero']],
+        [OptionalValue.FALSE, ['false']],
+        [OptionalValue.NAN, ['nan']],
+        [OptionalValue.FALSY, ['undefined', 'null', 'emptyString', 'zero', 'false', 'nan']],
+    ];
+
+    for (const [atom, matching] of table) {
+        describe(`'${atom}'`, () => {
+            const keys = Object.keys(values);
+            for (const key of keys) {
+                const expected = matching.includes(key);
+                it(`should ${expected ? 'match' : 'not match'} ${key}`, () => {
+                    expect(isOptionalValue(values[key], atom)).toEqual(expected);
+                });
+            }
+        });
+    }
+
+    it('should default to UNDEFINED when no definition is supplied', () => {
+        expect(isOptionalValue(undefined)).toEqual(true);
+        expect(isOptionalValue(null)).toEqual(false);
+        expect(isOptionalValue('')).toEqual(false);
+        expect(isOptionalValue(0)).toEqual(false);
+    });
+
+    it('should not widen NULL to include undefined', () => {
+        expect(isOptionalValue(undefined, OptionalValue.NULL)).toEqual(false);
+    });
+
+    it('should treat the array form as any-of', () => {
+        const definition = [OptionalValue.NULL, OptionalValue.EMPTY_STRING];
+
+        expect(isOptionalValue(null, definition)).toEqual(true);
+        expect(isOptionalValue('', definition)).toEqual(true);
+        expect(isOptionalValue(undefined, definition)).toEqual(false);
+        expect(isOptionalValue(0, definition)).toEqual(false);
+    });
+
+    it('should never match for an empty array', () => {
+        expect(isOptionalValue(undefined, [])).toEqual(false);
+        expect(isOptionalValue(null, [])).toEqual(false);
+    });
+
+    it('should tolerate FALSY mixed with atoms', () => {
+        const definition = [OptionalValue.FALSY, OptionalValue.NULL];
+
+        expect(isOptionalValue(0, definition)).toEqual(true);
+        expect(isOptionalValue(null, definition)).toEqual(true);
+        expect(isOptionalValue('x', definition)).toEqual(false);
+    });
+
+    it('should not match an unknown atom', () => {
+        expect(isOptionalValue(undefined, 'bogus' as any)).toEqual(false);
+    });
+
+    it('should only match NaN for numeric NaN', () => {
+        expect(isOptionalValue(Number.NaN, OptionalValue.NAN)).toEqual(true);
+        // `Number.isNaN('x')` is false, but a naive `isNaN('x')` would be true.
+        expect(isOptionalValue('x', OptionalValue.NAN)).toEqual(false);
+    });
+});

--- a/packages/validup/test/unit/path-filter.spec.ts
+++ b/packages/validup/test/unit/path-filter.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolvePathFilter } from '../../src';
+
+/**
+ * `resolvePathFilter` is the include/exclude verdict the run loops consult via
+ * `Container.prepareMountKey`. Asserted here at its own edge —
+ * `paths-to-include.spec.ts` covers how the container *uses* it.
+ */
+describe('resolvePathFilter', () => {
+    it('should forward filters verbatim for a keyless mount', () => {
+        expect(resolvePathFilter(['a.b'], ['c'], '', true)).toEqual({
+            skip: false,
+            pathsToInclude: ['a.b'],
+            pathsToExclude: ['c'],
+        });
+    });
+
+    it('should pass through when no filter is set', () => {
+        expect(resolvePathFilter(undefined, undefined, 'name', false)).toEqual({
+            skip: false,
+            pathsToInclude: undefined,
+            pathsToExclude: undefined,
+        });
+    });
+
+    describe('pathsToInclude', () => {
+        it('should keep an exact match and stop forwarding', () => {
+            expect(resolvePathFilter(['name'], undefined, 'name', false)).toEqual({
+                skip: false,
+                pathsToInclude: undefined,
+                pathsToExclude: undefined,
+            });
+        });
+
+        it('should skip a mount no entry targets', () => {
+            expect(resolvePathFilter(['other'], undefined, 'name', false).skip).toEqual(true);
+        });
+
+        it('should descend into a container mount with the prefix stripped', () => {
+            expect(resolvePathFilter(['address.city'], undefined, 'address', true)).toEqual({
+                skip: false,
+                pathsToInclude: ['city'],
+                pathsToExclude: undefined,
+            });
+        });
+
+        it('should skip a validator mount when only a deeper path is targeted', () => {
+            expect(resolvePathFilter(['address.city'], undefined, 'address', false).skip).toEqual(true);
+        });
+
+        it('should prefer an exact match over a sibling prefix descent', () => {
+            expect(resolvePathFilter(['address', 'address.city'], undefined, 'address', true)).toEqual({
+                skip: false,
+                pathsToInclude: undefined,
+                pathsToExclude: undefined,
+            });
+        });
+    });
+
+    describe('pathsToExclude', () => {
+        it('should skip an exact match', () => {
+            expect(resolvePathFilter(undefined, ['name'], 'name', false).skip).toEqual(true);
+        });
+
+        it('should keep a mount no entry targets', () => {
+            expect(resolvePathFilter(undefined, ['other'], 'name', false)).toEqual({
+                skip: false,
+                pathsToInclude: undefined,
+                pathsToExclude: undefined,
+            });
+        });
+
+        it('should descend into a container mount with the prefix stripped', () => {
+            expect(resolvePathFilter(undefined, ['address.city'], 'address', true)).toEqual({
+                skip: false,
+                pathsToInclude: undefined,
+                pathsToExclude: ['city'],
+            });
+        });
+
+        it('should keep a validator mount when only a deeper path is excluded', () => {
+            expect(resolvePathFilter(undefined, ['address.city'], 'address', false)).toEqual({
+                skip: false,
+                pathsToInclude: undefined,
+                pathsToExclude: undefined,
+            });
+        });
+    });
+
+    it('should let an exclude entry win over a matching include entry', () => {
+        expect(resolvePathFilter(['name'], ['name'], 'name', false).skip).toEqual(true);
+    });
+
+    it('should forward both stripped lists for a container mount', () => {
+        expect(resolvePathFilter(
+            ['address.city', 'address.zip'],
+            ['address.zip'],
+            'address',
+            true,
+        )).toEqual({
+            skip: false,
+            pathsToInclude: ['city', 'zip'],
+            pathsToExclude: ['zip'],
+        });
+    });
+
+    it('should not treat a shared name prefix as a descent', () => {
+        // `addressLine` must not match the `address` mount.
+        expect(resolvePathFilter(['addressLine'], undefined, 'address', true).skip).toEqual(true);
+    });
+});

--- a/packages/validup/test/unit/run-parity.spec.ts
+++ b/packages/validup/test/unit/run-parity.spec.ts
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    Container,
+    OptionalValue,
+    ResultCache,
+    defineValidator,
+    flattenIssueItems,
+} from '../../src';
+import type { Validator } from '../../src';
+import { expectRunFailureParity, expectRunParity } from '../helpers/parity';
+import { stringValidatorSync } from '../data';
+
+const failing: Validator = () => {
+    throw new Error('nope');
+};
+
+/**
+ * `run` and `runSync` are two drivers over one twin body
+ * (`Container.runBody`), so every mount-resolution rule has to resolve
+ * identically on both. These are the table-driven assertions of that contract
+ * — the per-variant specs (`module.spec.ts`, `run-sync.spec.ts`,
+ * `optional.spec.ts`, …) keep covering the behaviour itself.
+ */
+describe('run/runSync parity', () => {
+    it('should agree on a plain successful run', async () => {
+        const container = new Container<{ name: string, age: number }>();
+        container.mount('name', stringValidatorSync);
+        container.mount('age', (ctx) => ctx.value);
+
+        const output = await expectRunParity(container, { name: 'Peter', age: 30 });
+        expect(output).toEqual({ name: 'Peter', age: 30 });
+    });
+
+    it('should agree on the sequential chain-read of a sanitized sibling', async () => {
+        const container = new Container<{ name: string }>();
+        container.mount('name', (ctx) => String(ctx.value).trim());
+        container.mount('name', (ctx) => `${ctx.value}!`);
+
+        const output = await expectRunParity(container, { name: '  Peter  ' });
+        expect(output).toEqual({ name: 'Peter!' });
+    });
+
+    describe('optional gate', () => {
+        it('should agree on the boolean gate + default optionalValue', async () => {
+            const container = new Container<{ name: string }>();
+            container.mount('name', { optional: true }, stringValidatorSync);
+
+            const output = await expectRunParity(container, {});
+            expect(Object.keys(output)).toHaveLength(0);
+        });
+
+        it('should agree on a predicate gate winning over the atom vocabulary', async () => {
+            const container = new Container<{ name: string }>();
+            container.mount(
+                'name',
+                {
+                    optional: (value) => value === 'skip',
+                    optionalValue: OptionalValue.UNDEFINED,
+                },
+                failing,
+            );
+
+            const output = await expectRunParity(container, { name: 'skip' });
+            expect(Object.keys(output)).toHaveLength(0);
+        });
+
+        it('should agree on optionalInclude copying the input through', async () => {
+            const container = new Container<{ name: string }>();
+            container.mount(
+                'name',
+                {
+                    optional: true,
+                    optionalValue: OptionalValue.EMPTY_STRING,
+                    optionalInclude: true,
+                },
+                failing,
+            );
+
+            const output = await expectRunParity(container, { name: '' });
+            expect(output).toEqual({ name: '' });
+        });
+
+        it('should agree on the array (any-of) optionalValue form', async () => {
+            const container = new Container<{ name: string }>();
+            container.mount(
+                'name',
+                {
+                    optional: true,
+                    optionalValue: [OptionalValue.NULL, OptionalValue.EMPTY_STRING],
+                },
+                failing,
+            );
+
+            expect(Object.keys(await expectRunParity(container, { name: null as any }))).toHaveLength(0);
+            expect(Object.keys(await expectRunParity(container, { name: '' }))).toHaveLength(0);
+        });
+    });
+
+    describe('optionalValue precedence', () => {
+        it('should agree that the mount layer wins over run and container', async () => {
+            const container = new Container<{ name: string }>({ optionalValue: OptionalValue.NULL });
+            container.mount(
+                'name',
+                {
+                    optional: true,
+                    optionalValue: OptionalValue.EMPTY_STRING,
+                },
+                failing,
+            );
+
+            expect(Object.keys(await expectRunParity(
+                container,
+                { name: '' },
+                { optionalValue: OptionalValue.ZERO },
+            ))).toHaveLength(0);
+        });
+
+        it('should agree that the run layer wins over the container layer', async () => {
+            const container = new Container<{ name: string }>({ optionalValue: OptionalValue.NULL });
+            container.mount('name', { optional: true }, failing);
+
+            expect(Object.keys(await expectRunParity(
+                container,
+                { name: '' },
+                { optionalValue: OptionalValue.EMPTY_STRING },
+            ))).toHaveLength(0);
+        });
+
+        it('should agree on the container layer as the last stop before the default', async () => {
+            const container = new Container<{ name: string }>({ optionalValue: OptionalValue.EMPTY_STRING });
+            container.mount('name', { optional: true }, failing);
+
+            expect(Object.keys(await expectRunParity(container, { name: '' }))).toHaveLength(0);
+        });
+    });
+
+    describe('optionalAs precedence', () => {
+        it('should agree that the mount layer wins', async () => {
+            const container = new Container<{ name: string }>({ optionalAs: 'container' });
+            container.mount('name', { optional: true, optionalAs: 'mount' }, failing);
+
+            expect(await expectRunParity(container, {}, { optionalAs: 'run' }))
+                .toEqual({ name: 'mount' });
+        });
+
+        it('should agree that the run layer wins over the container layer', async () => {
+            const container = new Container<{ name: string }>({ optionalAs: 'container' });
+            container.mount('name', { optional: true }, failing);
+
+            expect(await expectRunParity(container, {}, { optionalAs: 'run' }))
+                .toEqual({ name: 'run' });
+        });
+
+        it('should agree that presence — not value — activates the directive', async () => {
+            const container = new Container<{ name: string }>();
+            container.mount('name', { optional: true, optionalAs: undefined }, failing);
+
+            const output = await expectRunParity(container, {});
+            // Key present, value `undefined` — distinct from "omit the key".
+            expect(Object.keys(output)).toEqual(['name']);
+            expect(output.name).toBeUndefined();
+        });
+
+        it('should agree that optionalAs outranks optionalInclude', async () => {
+            const container = new Container<{ name: string }>();
+            container.mount(
+                'name',
+                {
+                    optional: true,
+                    optionalValue: OptionalValue.EMPTY_STRING,
+                    optionalAs: null,
+                    optionalInclude: true,
+                },
+                failing,
+            );
+
+            expect(await expectRunParity(container, { name: '' })).toEqual({ name: null });
+        });
+    });
+
+    describe('nested containers', () => {
+        it('should agree on nested output merging', async () => {
+            const child = new Container<{ city: string }>();
+            child.mount('city', stringValidatorSync);
+
+            const parent = new Container<{ address: { city: string } }>();
+            parent.mount('address', child);
+
+            expect(await expectRunParity(parent, { address: { city: 'Berlin' } }))
+                .toEqual({ address: { city: 'Berlin' } });
+        });
+
+        it('should agree on the forwarded optionalValue / optionalAs bag', async () => {
+            const child = new Container<{ city: string }>();
+            child.mount('city', { optional: true }, failing);
+
+            const parent = new Container<{ address: { city: string } }>();
+            parent.mount('address', child);
+
+            expect(await expectRunParity(
+                parent,
+                { address: { city: '' } },
+                {
+                    optionalValue: OptionalValue.EMPTY_STRING,
+                    optionalAs: null,
+                },
+            )).toEqual({ address: { city: null } });
+        });
+
+        it('should agree on the forwarded defaults slice', async () => {
+            const child = new Container<{ city: string, zip: string }>();
+            child.mount('city', stringValidatorSync);
+
+            const parent = new Container<{ address: { city: string, zip: string } }>();
+            parent.mount('address', child);
+
+            expect(await expectRunParity(
+                parent,
+                { address: { city: 'Berlin' } },
+                { defaults: { 'address.zip': '10115' } as any },
+            )).toEqual({ address: { city: 'Berlin', zip: '10115' } });
+        });
+
+        it('should agree on nested issue paths', async () => {
+            const child = new Container<{ city: string }>();
+            child.mount('city', failing);
+
+            const parent = new Container<{ address: { city: string } }>();
+            parent.mount('address', child);
+
+            const issues = await expectRunFailureParity(parent, { address: { city: 1 as any } });
+            expect(flattenIssueItems(issues as any).map((item) => item.path))
+                .toEqual([['address', 'city']]);
+        });
+    });
+
+    describe('filters and groups', () => {
+        it('should agree on group filtering', async () => {
+            const container = new Container<{ name: string, age: number }>();
+            container.mount('name', { group: ['create'] }, stringValidatorSync);
+            container.mount('age', { group: ['update'] }, failing);
+
+            expect(await expectRunParity(
+                container,
+                { name: 'Peter', age: 30 },
+                { group: 'create' },
+            )).toEqual({ name: 'Peter' });
+        });
+
+        it('should agree on pathsToInclude / pathsToExclude', async () => {
+            const container = new Container<{ name: string, age: number }>();
+            container.mount('name', stringValidatorSync);
+            container.mount('age', failing);
+
+            expect(await expectRunParity(
+                container,
+                { name: 'Peter', age: 30 },
+                { pathsToInclude: ['name'] },
+            )).toEqual({ name: 'Peter' });
+
+            expect(await expectRunParity(
+                container,
+                { name: 'Peter', age: 30 },
+                { pathsToExclude: ['age'] },
+            )).toEqual({ name: 'Peter' });
+        });
+
+        it('should agree on defaults backfill', async () => {
+            const container = new Container<{ name: string, age: number }>();
+            container.mount('name', stringValidatorSync);
+
+            expect(await expectRunParity(
+                container,
+                { name: 'Peter' },
+                { defaults: { age: 30 } },
+            )).toEqual({ name: 'Peter', age: 30 });
+        });
+
+        it('should agree on flat output', async () => {
+            const child = new Container<{ city: string }>();
+            child.mount('city', stringValidatorSync);
+
+            const parent = new Container<{ address: { city: string } }>();
+            parent.mount('address', child);
+
+            expect(await expectRunParity(
+                parent,
+                { address: { city: 'Berlin' } },
+                { flat: true },
+            )).toEqual({ 'address.city': 'Berlin' });
+        });
+    });
+
+    describe('failures', () => {
+        it('should agree on the aggregated issue tree', async () => {
+            const container = new Container<{ name: string, age: number }>();
+            container.mount('name', failing);
+            container.mount('age', failing);
+
+            const issues = await expectRunFailureParity(container, { name: 1 as any, age: 'x' as any });
+            expect(issues).toHaveLength(2);
+        });
+
+        it('should agree on the meta.optional stamp for a boolean-optional mount', async () => {
+            // `optional: true` tags unconditionally — the stamp reflects the
+            // mount's *declaration*, not whether the gate fired for this value.
+            const container = new Container<{ name: string }>();
+            container.mount(
+                'name',
+                {
+                    optional: true,
+                    optionalValue: OptionalValue.EMPTY_STRING,
+                },
+                failing,
+            );
+
+            const issues = await expectRunFailureParity(container, { name: 'x' });
+            expect(flattenIssueItems(issues as any)[0].meta).toEqual({ optional: true });
+        });
+
+        it('should agree that a predicate-optional mount is re-evaluated at error time', async () => {
+            const container = new Container<{ name: string }>();
+            container.mount(
+                'name',
+                { optional: (value) => value === 'skip' },
+                failing,
+            );
+
+            const issues = await expectRunFailureParity(container, { name: 'x' });
+            expect(flattenIssueItems(issues as any)[0].meta).toBeUndefined();
+        });
+
+        it('should agree that meta.optional is not inherited by a child container leaf', async () => {
+            const child = new Container<{ city: string }>();
+            child.mount('city', failing);
+
+            const parent = new Container<{ address: { city: string } }>();
+            parent.mount('address', { optional: true }, child);
+
+            const issues = await expectRunFailureParity(parent, { address: { city: 1 as any } });
+            // Wrapping group carries the flag; the leaf inside does not.
+            expect((issues[0] as any).meta).toEqual({ optional: true });
+            expect(flattenIssueItems(issues as any)[0].meta).toBeUndefined();
+        });
+
+        it('should agree on oneOf aggregation when every branch fails', async () => {
+            const container = new Container<{ name: string, age: number }>({ oneOf: true });
+            container.mount('name', failing);
+            container.mount('age', failing);
+
+            const issues = await expectRunFailureParity(container, { name: 1 as any, age: 'x' as any });
+            expect(issues).toHaveLength(1);
+        });
+
+        it('should agree on oneOf succeeding when one branch passes', async () => {
+            const container = new Container<{ name: string, age: number }>({ oneOf: true });
+            container.mount('name', stringValidatorSync);
+            container.mount('age', failing);
+
+            expect(await expectRunParity(container, { name: 'Peter', age: 30 }))
+                .toEqual({ name: 'Peter' });
+        });
+    });
+
+    describe('result cache', () => {
+        it('should agree that a hit is replayed rather than re-invoked', async () => {
+            let calls = 0;
+            const container = new Container<{ name: string }>();
+            container.mount('name', (ctx) => {
+                calls++;
+                return ctx.value;
+            });
+
+            const cache = new ResultCache();
+            // Seed via `run`, replay via `runSync` — one shared cache, one
+            // shared body, so the second variant must not re-invoke.
+            expect(await container.run({ name: 'Peter' }, { cache })).toEqual({ name: 'Peter' });
+            expect(calls).toEqual(1);
+            expect(container.runSync({ name: 'Peter' }, { cache })).toEqual({ name: 'Peter' });
+            expect(calls).toEqual(1);
+        });
+
+        it('should agree that a sideEffect mount is never cached', async () => {
+            let calls = 0;
+            const container = new Container<{ name: string }>();
+            container.mount('name', defineValidator({
+                sideEffect: true,
+                run: (ctx) => {
+                    calls++;
+                    return ctx.value;
+                },
+            }));
+
+            const cache = new ResultCache();
+            await container.run({ name: 'Peter' }, { cache });
+            container.runSync({ name: 'Peter' }, { cache });
+
+            expect(calls).toEqual(2);
+        });
+
+        it('should agree that a failure outcome replays as a failure', async () => {
+            let calls = 0;
+            const container = new Container<{ name: string }>();
+            container.mount('name', () => {
+                calls++;
+                throw new Error('nope');
+            });
+
+            const cache = new ResultCache();
+            const async = await container.safeRun({ name: 'x' }, { cache });
+            const sync = container.safeRunSync({ name: 'x' }, { cache });
+
+            expect(calls).toEqual(1);
+            expect(async.success).toEqual(false);
+            expect(sync.success).toEqual(false);
+            if (!async.success && !sync.success) {
+                expect(sync.error.issues).toEqual(async.error.issues);
+            }
+        });
+    });
+});

--- a/packages/validup/test/unit/twin.spec.ts
+++ b/packages/validup/test/unit/twin.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { TwinBody } from '../../src/utils/twin';
+import { op, runTwinAsync, runTwinSync } from '../../src/utils/twin';
+
+describe('twin', () => {
+    it('should drive the side the driver stands for', async () => {
+        const seen: string[] = [];
+
+        function* body() : TwinBody<string> {
+            return yield* op(
+                () => {
+                    seen.push('async');
+                    return Promise.resolve('a');
+                },
+                () => {
+                    seen.push('sync');
+                    return 's';
+                },
+            );
+        }
+
+        expect(await runTwinAsync(body())).toEqual('a');
+        expect(runTwinSync(body())).toEqual('s');
+        expect(seen).toEqual(['async', 'sync']);
+    });
+
+    it('should await a bare (non-promise) async thunk return', async () => {
+        function* body() : TwinBody<number> {
+            return yield* op(() => 1, () => 1);
+        }
+
+        expect(await runTwinAsync(body())).toEqual(1);
+    });
+
+    it('should thread each effect result back into the body', async () => {
+        function* body() : TwinBody<number> {
+            const a = yield* op(() => Promise.resolve(2), () => 2);
+            const b = yield* op(() => Promise.resolve(a * 3), () => a * 3);
+            return b + 1;
+        }
+
+        expect(await runTwinAsync(body())).toEqual(7);
+        expect(runTwinSync(body())).toEqual(7);
+    });
+
+    it('should re-enter effect errors so in-body try/catch behaves identically', async () => {
+        function* body() : TwinBody<string> {
+            try {
+                yield* op(
+                    () => Promise.reject(new Error('async boom')),
+                    () => {
+                        throw new Error('sync boom');
+                    },
+                );
+                return 'not reached';
+            } catch (e) {
+                return `caught: ${(e as Error).message}`;
+            }
+        }
+
+        expect(await runTwinAsync(body())).toEqual('caught: async boom');
+        expect(runTwinSync(body())).toEqual('caught: sync boom');
+    });
+
+    it('should run in-body finally blocks on both sides', async () => {
+        const seen: string[] = [];
+
+        function* body() : TwinBody<void> {
+            try {
+                yield* op(
+                    () => Promise.reject(new Error('boom')),
+                    () => {
+                        throw new Error('boom');
+                    },
+                );
+            } catch {
+                seen.push('catch');
+            } finally {
+                seen.push('finally');
+            }
+        }
+
+        await runTwinAsync(body());
+        runTwinSync(body());
+
+        expect(seen).toEqual(['catch', 'finally', 'catch', 'finally']);
+    });
+
+    it('should propagate an uncaught effect error out of the driver', async () => {
+        function* body() : TwinBody<void> {
+            yield* op(
+                () => Promise.reject(new Error('escapes')),
+                () => {
+                    throw new Error('escapes');
+                },
+            );
+        }
+
+        await expect(runTwinAsync(body())).rejects.toThrow('escapes');
+        expect(() => runTwinSync(body())).toThrow('escapes');
+    });
+
+    it('should compose bodies via yield* delegation', async () => {
+        function* inner(input: number) : TwinBody<number> {
+            return yield* op(() => Promise.resolve(input * 2), () => input * 2);
+        }
+
+        function* outer() : TwinBody<number> {
+            const a = yield* inner(2);
+            const b = yield* inner(a);
+            return b;
+        }
+
+        expect(await runTwinAsync(outer())).toEqual(8);
+        expect(runTwinSync(outer())).toEqual(8);
+    });
+
+    it('should not introduce a microtask on the sync side', () => {
+        let flushed = false;
+        Promise.resolve().then(() => {
+            flushed = true;
+        });
+
+        function* body() : TwinBody<boolean> {
+            return yield* op(() => Promise.resolve(flushed), () => flushed);
+        }
+
+        expect(runTwinSync(body())).toEqual(false);
+        expect(flushed).toEqual(false);
+    });
+});


### PR DESCRIPTION
Implements `.agents/plans/004-container-run-loop-unification.md`.

## Problem

`run`, `runSync` and `runParallel` were three copies of the same ~150-line mount-resolution loop — 670 of `container/module.ts`'s 1575 lines. Comment-stripped, `run` and `runSync` differed in roughly two dozen lines: the `await`s and two structural probes. Every new mount option had to be threaded into three places identically or a variant silently diverged. `pathsStrict` (#424) paid that tax most recently.

## Approach

`run` and `runSync` now collapse into **one** private generator, `Container.runBody`, driven by `runTwinAsync` / `runTwinSync`.

The protocol lives in `src/utils/twin.ts` — internal, deliberately not in any barrel, same treatment as `container/run-sync-violation.ts`. It is ported from [`tada5hi/locter`](https://github.com/tada5hi/locter)'s `src/utils/twin.ts` with one deviation: the async thunk may return a bare value as well as a promise, because a validup `Validator` is free to be synchronous.

A body yields effect pairs via `yield* op(asyncThunk, syncThunk)`, and effect errors re-enter at the `yield` site via `Generator.throw` — which is what lets the cache-write and issue-collection `try`/`catch` blocks exist exactly once. `runBody` yields the loop's only two impure edges:

| Effect | async thunk | sync thunk |
|---|---|---|
| nested container | `child.run(...)` | `child.runSync(...)`, throwing `RunSyncViolationError` when absent |
| validator | `validator(ctx)` | `validator(ctx)`, throwing when the return value is thenable |

Both `runSync`-only structural probes therefore live *inside the sync thunk*, where the async side cannot reach them. `runSync` is now one line.

### `runParallel` stays separate — on purpose

A generator is sequential by construction. Expressing "launch every mount, then settle" through it would mean yielding batches *and* surrendering the sequential chain-read that distinguishes the two modes. Instead it shares every extracted per-key helper:

| Helper | Answers |
|---|---|
| `prepareMountKey` | `keyParts` / `pathRelative` / `pathAbsolute` / include-exclude verdict |
| `resolveOptionalDirective` | skip or proceed, and what a skipped key writes |
| `buildChildRunOptions` | the child-container forward bag — one source of truth |
| `buildValidatorContext` | the `ValidatorContext` handed to a validator |

That removes its duplicated key-preparation block. `prepareMountKey` deliberately does **not** read the mount's input `value` — the sequential-vs-parallel value-source asymmetry is documented behaviour, so it stays in the caller and the helper stays pure.

`assertPathsStrict` moved from `run()`'s pre-delegation slot into `runParallel` itself, still ahead of any promise creation.

Net effect: adding a run option is now two edits (body + `buildChildRunOptions`) instead of six, and `runParallel` picks up anything the shared helpers resolve for free.

## Behaviour

Behaviour-preserving. **No existing spec changed.** The invariants plan §7 flagged as fragile are all still covered: the sequential chain-read, parallel issue ordering, `optionalAs` presence semantics, structural throws bypassing the issue fold, `initialize()`, and the `meta.optional` no-inheritance rule.

One guard was unified in passing: "don't cache a `RunSyncViolationError`" was `runSync`-only and now applies to both variants. It is unreachable on the async side except for a validator letting one escape — which `collectExecutionFailure` already rethrows structurally, so not caching it is the consistent reading.

## Tests

Core suite **240 → 377**. All five packages' tests, the full `nx` build, and lint are green.

- `test/helpers/parity.ts` — `expectRunParity` / `expectRunFailureParity`, asserting the `run` ↔ `runSync` contract once instead of per-variant
- `test/unit/run-parity.spec.ts` — plan §5's resolution table: optional gate, the four-layer `optionalValue` / `optionalAs` precedence chains, filters, groups, defaults, nested forwarding, `oneOf`, cache replay
- `test/unit/twin.spec.ts` — the protocol itself, including error re-entry, `finally`, `yield*` composition, and that the sync driver queues no microtask
- `test/unit/{optional-value,path-filter,defaults}.spec.ts` — plan §5's "also unlocked": three helpers that previously had no direct spec, reachable only through the 196/198/276-line methods
- `test/data/string-validator.ts` gained `stringValidatorSync` (parity specs can't drive a thenable validator)

## Docs

All three surfaces updated in the same pass, per `.agents/conventions.md`: `packages/validup/README.md`, `docs/src/guide/run-modes.md`, and `.agents/{architecture,structure,testing,conventions}.md`.

## Note on line count

`module.ts` went 1575 → 1554. The *duplication* is gone, but ~190 lines of removed copy-paste were traded for named, documented helpers, so the plan's "40% of core" framing is unresolved. Extracting `assertPathsStrict` and `collectExecutionFailure` into their own modules is the obvious next cut.

## Follow-up

Three repos now carry a hand-copied twin protocol — locter, ilingo (`packages/fs`) and validup — already three-way drifted. Extracted to [`tada5hi/twinop`](https://github.com/tada5hi/twinop); swapping all three over to it once published is a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Behavior**
  * Unified `run()` and `runSync()` processing for more consistent validation results, options, filtering, optional handling, and nested container behavior.
  * Improved synchronization checks and error handling when asynchronous validators are used in sync mode.
  * Ensured cache behavior remains consistent across asynchronous and synchronous runs.

* **Documentation**
  * Clarified run modes, sync-mode limitations, caching, and shared execution behavior.

* **Tests**
  * Added extensive coverage for async/sync parity, filtering, defaults, optional values, caching, and execution edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->