### PR TITLE
docs(integrations): show how to combine adapters in one file

### DIFF
--- a/docs/src/integrations/index.md
+++ b/docs/src/integrations/index.md
@@ -21,6 +21,37 @@ These come in three flavors today:
 | [`@validup/zod`](/integrations/zod)               | [zod](https://zod.dev) v4         | You need vendor-specific issue fields (`expected`, `received`) |
 | [`@validup/validator-js`](/integrations/validator-js) | [validator.js](https://github.com/validatorjs/validator.js) string validators (`isEmail`, `isLength`, `isInt`, …) | You want pre-baked factories for the common rules with vocabulary codes baked in |
 
+All three adapters name that entry point `createValidator` on purpose — same role, same contract, one thing to learn. The symmetry costs you an alias when two of them (or an adapter and the library it wraps) meet in one file.
+
+### Combining adapters in one file
+
+`@validup/validator-js` names its factories after the validator.js rules they wrap — `isEmail`, `isURL`, `isUUID`, `isInt`, `equals`, `matches`, `isDate` — so the collision to plan for is usually with **validator.js itself** (reached for directly for the long tail: `isCreditCard`, `isJWT`, …), not just with a sibling adapter.
+
+A namespace import resolves every name at once and reads better than aliasing them one by one:
+
+```typescript
+import * as vjs from '@validup/validator-js';
+import validator from 'validator';
+import { createValidator as createZod } from '@validup/zod';
+import { z } from 'zod';
+
+// zod for schema-shaped fields …
+container.mount('email', createZod(z.string().email()));
+
+// … validator-js factories for vocabulary rules, with issue codes baked in
+container.mount('passwordConfirm', vjs.equals('password'));
+
+// … and validator.js directly for anything not pre-baked
+container.mount('card', vjs.createValidator(validator.isCreditCard, { code: 'credit_card' }));
+```
+
+Aliasing individual imports works too, and is the lighter touch when you only need one or two symbols:
+
+```typescript
+import { createValidator as createZod } from '@validup/zod';
+import { createValidator as createStandard } from '@validup/standard-schema';
+```
+
 **Framework / runtime integrations** consume a whole `Container<T, C>` and wire it into a host environment:
 
 | Package                             | Host                                       |


### PR DESCRIPTION
Follow-up to #447, which is closed without merging.

All three validator adapters name their entry point `createValidator` — same role, same contract, one thing to learn. The cost of that symmetry is an alias when two of them meet in one file, and that was undocumented. This documents it.

## Why not just rename them

#447 proposed `createZodValidator` / `createStandardSchemaValidator` / `createValidatorJsValidator`. Dropped, because it closes the rarest collision and leaves the likeliest one:

- `createValidator` only collided across sibling validup adapters — needing two adapters in one file, which no file in the repo does.
- `@validup/validator-js` names its factories after the validator.js rules they wrap, so **7 of them collide with validator.js itself**: `isEmail`, `isURL`, `isUUID`, `isInt`, `equals`, `matches`, `isDate`. Reaching for `validator` directly for the long tail (`isCreditCard`, `isJWT`) alongside the pre-baked factories is the documented usage pattern, so that collision is the default path rather than a prospective one. `equals` / `matches` / `isDate` also collide with Ramda, lodash and date-fns.

A namespace import fixes all 20 names at once. No rename can, short of `validatorJsIsEmail` across all 19 factories — which is the reductio that makes the rename a one-off rather than a convention.

Full reasoning is recorded on #447 so it does not get re-proposed from scratch.

## What this adds

A short "Combining adapters in one file" section on the integrations overview — where a reader combining packages is already looking — showing the namespace import as the primary form and per-symbol aliasing as the lighter touch:

```typescript
import * as vjs from '@validup/validator-js';
import validator from 'validator';
import { createValidator as createZod } from '@validup/zod';

container.mount('email', createZod(z.string().email()));
container.mount('passwordConfirm', vjs.equals('password'));
container.mount('card', vjs.createValidator(validator.isCreditCard, { code: 'credit_card' }));
```

Both signatures in the example were checked against `master`: `equals(key, options?)` takes an optional second arg, and `createValidator(fn, options)` requires `options.code`.

Docs-only — no source, no public API change. `@validup/docs:build` and `npm run lint` pass.
