### PR TITLE
fix(validup): route compose's fold sites through isStructuralThrow

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -203,14 +203,18 @@ Consulted at the two sites that fold a throw into issues — `collectExecutionFa
 
 These two differ from the fold sites in *how* they use the predicate: they **suppress a side effect** rather than decide a throw (the rethrow sits unconditionally outside the guard). That is why the predicate must stay a plain boolean rather than becoming a throw-helper.
 
-**`helpers/compose.ts` has two more under-guarded fold sites**, and the one with *no* guard at all is the less obvious of the two:
+**`helpers/compose.ts`'s two fold sites now use it too**, closing the last gap. They had diverged the same way the cache-write pair had:
 
-| Site | Reached via | Filters today | Gap |
+| Site | Reached via | Filtered before | Now |
 |---|---|---|---|
-| `composeAnyOf`'s per-branch catch | `composeOneOf(...)` / `compose(..., { oneOf: true })` | the abort leg alone (`ctx.signal?.aborted`) | a `PathsStrictViolationError` / `RunSyncViolationError` escaping a container element is folded into branch issues |
-| `compose`'s collect-all catch | `compose(..., { bail: false })` | **nothing** — no abort read, no `isRunSyncViolation`, no `isPathsStrictViolation` | folds straight through `errorToIssues` and re-throws as a generic aggregate `ValidupError`, so the caller cannot tell "misconfigured graph" or "cancelled" from "validation failed" |
+| `composeAnyOf`'s per-branch catch | `composeOneOf(...)` / `compose(..., { oneOf: true })` | the abort leg alone (`ctx.signal?.aborted`) | full `isStructuralThrow` — a container element's `PathsStrictViolationError` / `RunSyncViolationError` is no longer buried under `ONE_OF_FAILED` |
+| `compose`'s collect-all catch | `compose(..., { bail: false })` | **nothing** — no abort read, neither error-type leg | `bail \|\| isStructuralThrow(...)`; the caller can again tell "misconfigured graph" and "cancelled" from "validation failed" |
 
-The `bail: true` default re-throws the first failure verbatim, so only the explicit `{ bail: false }` opt-in reaches the second row. Adopting `isStructuralThrow` at either site is a behaviour change (issues that used to be collected would become throws), so it belongs in its own commit with `compose.spec.ts` cases for both strategies. These are now the **only** remaining under-guarded fold sites — the cache-write pair above was unified.
+The `bail: true` default already re-threw the first failure verbatim, so only the explicit `{ bail: false }` opt-in was ever affected on the second row — which is why the gap survived so long. Both are covered by `compose.spec.ts` → "compose — structural throws are not folded into issues", which pairs each propagation case with an ordinary-failure case so the widening cannot silently swallow real validation issues.
+
+`compose.ts` reaches the predicate through the **leaf** module (`../container/structural-throw`), not the `../container` barrel — the same cycle discipline its `isContainer` import already follows.
+
+With this, every fold site in the codebase consults one predicate. There are no known under-guarded sites left.
 
 **When adding a run or mount option**, thread it through the twin body plus (if a child inherits it) `buildChildRunOptions` — two edits, not six. `runParallel` picks up anything the shared helpers resolve for free; only genuinely scheduling-specific behaviour needs a second touch there.
 
@@ -260,7 +264,7 @@ type ComposeOptions =
 ```
 
 - **`oneOf: false`** (default) — every element must pass. Sequential loop; each stage's defined return replaces the threaded `ctx.value` (a `undefined` return passes through). `bail: true` (default) re-throws the first failure verbatim; `bail: false` collects every failure into one aggregate `ValidupError` and threads through throwing stages so the next branch still runs against the last successful value.
-- **`oneOf: true`** — branches run as alternatives in registration order. First defined return wins (with the same pass-through fallback to `ctx.value`); subsequent branches never run. All branches failing throws a `ValidupError` whose first issue is an `IssueGroup` with `code: IssueCode.ONE_OF_FAILED` carrying every branch's failures, each stamped with `data: { branch: index }` so consumers can attribute issues. Aborts via `ctx.signal` re-throw verbatim instead of being folded into branch failures. Empty branch list throws `ONE_OF_FAILED` with an empty inner list — "zero successes" is still zero successes.
+- **`oneOf: true`** — branches run as alternatives in registration order. First defined return wins (with the same pass-through fallback to `ctx.value`); subsequent branches never run. All branches failing throws a `ValidupError` whose first issue is an `IssueGroup` with `code: IssueCode.ONE_OF_FAILED` carrying every branch's failures, each stamped with `data: { branch: index }` so consumers can attribute issues. Aborts via `ctx.signal` — and structural violations from a container element — re-throw verbatim instead of being folded into branch failures (see [the structural carve-out](#the-structural-carve-out-isstructuralthrow)). Empty branch list throws `ONE_OF_FAILED` with an empty inner list — "zero successes" is still zero successes.
 
 `composeOneOf([...])` is sugar for `compose([...], { oneOf: true })`. The any-of path lives in a private `composeAnyOf` helper inside `compose.ts` so the main `compose` body stays focused on the all-strategy chain.
 

--- a/packages/validup/src/helpers/compose.ts
+++ b/packages/validup/src/helpers/compose.ts
@@ -6,6 +6,10 @@
  */
 
 import { isContainer } from '../container/check';
+// Leaf module, not the `../container` barrel — the barrel re-exports
+// `container/module.ts`, which imports from `../helpers`. Same discipline as
+// the `container/check` import above.
+import { isStructuralThrow } from '../container/structural-throw';
 import type { IContainer } from '../container/types';
 import { ValidupError } from '../error';
 import type { Issue } from '../issue';
@@ -164,7 +168,12 @@ export function compose<C = unknown>(
                     value = result;
                 }
             } catch (e) {
-                if (bail) {
+                // `bail` re-raises everything, so the structural check only
+                // matters for the `{ bail: false }` opt-in — which otherwise
+                // folds a cancelled run or a misconfigured graph into the
+                // aggregate `ValidupError` alongside real validation issues,
+                // leaving the caller unable to tell them apart.
+                if (bail || isStructuralThrow(e, ctx.signal)) {
                     throw e;
                 }
 
@@ -230,11 +239,16 @@ function composeAnyOf<C>(elements: ComposeElement<C>[]): Validator<C> {
                 // `ctx.value`, surface the input as the output.
                 return typeof result === 'undefined' ? ctx.value : result;
             } catch (e) {
-                // Cancellations from a branch validator surface
-                // verbatim instead of being folded into a branch
-                // failure — caller can distinguish "no branch matched"
-                // from "operation cancelled".
-                if (ctx.signal?.aborted) {
+                // Cancellations and structural graph violations surface
+                // verbatim instead of being folded into a branch failure —
+                // the caller can distinguish "no branch matched" from
+                // "operation cancelled" or "this graph is misconfigured".
+                //
+                // A container element raising `PathsStrictViolationError` or
+                // `RunSyncViolationError` is not a branch that "didn't match";
+                // it is a bug in the composition, and burying it under
+                // `ONE_OF_FAILED` hides the one diagnostic that identifies it.
+                if (isStructuralThrow(e, ctx.signal)) {
                     throw e;
                 }
 

--- a/packages/validup/test/unit/compose.spec.ts
+++ b/packages/validup/test/unit/compose.spec.ts
@@ -17,6 +17,7 @@ import {
     defineValidator,
     flattenIssueItems,
     isIssueGroup,
+    isPathsStrictViolation,
 } from '../../src';
 import type { Validator } from '../../src';
 
@@ -532,5 +533,87 @@ describe('createValidupError', () => {
     it('omits data when not provided', () => {
         const err = createValidupError(0, IssueCode.REQUIRED, 'required');
         expect(err.issues[0]?.data).toBeUndefined();
+    });
+});
+
+describe('compose — structural throws are not folded into issues', () => {
+    /**
+     * A child container whose strict pre-flight fails: `pathsToInclude` names a
+     * path no mount satisfies, so `run()` throws `PathsStrictViolationError`
+     * before any validator executes.
+     *
+     * That is a misconfigured graph, not a branch that "didn't match" — folding
+     * it into the issue list buries the one diagnostic that identifies it.
+     */
+    const strictChild = () => {
+        const child = new Container<any>({
+            pathsStrict: true,
+            pathsToInclude: ['does-not-exist'],
+        });
+        child.mount('foo', (ctx) => ctx.value);
+        return child;
+    };
+
+    const ctx = () => ({
+        key: 'root', 
+        path: [], 
+        value: { foo: 'x' }, 
+        data: {}, 
+        context: undefined,
+    }) as any;
+
+    it('should propagate a strict-paths violation out of compose({ bail: false })', async () => {
+        const validator = compose([strictChild()], { bail: false });
+
+        expect.assertions(2);
+        try {
+            await validator(ctx());
+        } catch (e) {
+            expect(isPathsStrictViolation(e)).toBe(true);
+            // Not reshaped into an aggregate ValidupError of branch issues.
+            expect(e).not.toBeInstanceOf(ValidupError);
+        }
+    });
+
+    it('should propagate a strict-paths violation out of composeOneOf', async () => {
+        const validator = composeOneOf([strictChild()]);
+
+        expect.assertions(2);
+        try {
+            await validator(ctx());
+        } catch (e) {
+            expect(isPathsStrictViolation(e)).toBe(true);
+            // Would otherwise arrive wrapped in an ONE_OF_FAILED group.
+            expect(e).not.toBeInstanceOf(ValidupError);
+        }
+    });
+
+    it('should still fold an ordinary branch failure under composeOneOf', async () => {
+        // Guards the widening above: a plain Error must NOT start propagating.
+        const validator = composeOneOf([() => {
+            throw new Error('BRANCH_FAILED');
+        }]);
+
+        expect.assertions(2);
+        try {
+            await validator(ctx());
+        } catch (e) {
+            expect(e).toBeInstanceOf(ValidupError);
+            expect((e as ValidupError).issues[0]).toMatchObject({ code: IssueCode.ONE_OF_FAILED });
+        }
+    });
+
+    it('should still fold an ordinary stage failure under compose({ bail: false })', async () => {
+        const validator = compose([() => {
+            throw new Error('STAGE_FAILED');
+        }], { bail: false });
+
+        expect.assertions(2);
+        try {
+            await validator(ctx());
+        } catch (e) {
+            expect(e).toBeInstanceOf(ValidupError);
+            expect((e as ValidupError).issues[0]).toMatchObject({ message: 'STAGE_FAILED' });
+        }
     });
 });


### PR DESCRIPTION
Closes the last two under-guarded fold sites, from `.agents/plans/005-error-issue-fold-consolidation.md`'s "Still open" list. With this, **every fold site in the codebase consults one predicate.**

## The gap

| Site | Reached via | Filtered before | Now |
|---|---|---|---|
| `composeAnyOf`'s per-branch catch | `composeOneOf(...)` / `compose(..., { oneOf: true })` | the abort leg alone (`ctx.signal?.aborted`) | full `isStructuralThrow` |
| `compose`'s collect-all catch | `compose(..., { bail: false })` | **nothing** — no abort read, neither error-type leg | `bail \|\| isStructuralThrow(...)` |

Consequences before this change:

- A container element raising `PathsStrictViolationError` inside `composeOneOf` was buried under an `ONE_OF_FAILED` group — reported as "no branch matched" when the real cause was a misconfigured graph, and the one diagnostic identifying it was gone.
- `{ bail: false }` folded a cancelled run or a structural violation into a generic aggregate `ValidupError`, so the caller could not tell it from ordinary validation failure.

The `bail: true` default already re-threw the first failure verbatim, which is why the second gap survived this long — only the explicit opt-in ever reached it.

## Cycle discipline

The predicate is imported from the **leaf** module (`../container/structural-throw`), not the `../container` barrel, matching the discipline compose's existing `isContainer` import already follows. `import/no-cycle` is unavailable in this repo's ESLint, so this is enforced by convention only.

## Tests

Four cases in `compose.spec.ts`, each **mutation-verified**: reverting `composeAnyOf`'s guard turns exactly its propagation case red (1 failure), reverting the `bail` guard turns exactly its own red (1 failure).

Each propagation case is deliberately paired with an **ordinary-failure** case — a plain `Error` must still fold into `ONE_OF_FAILED` / the aggregate. Without that pairing, a guard widened too far would swallow real validation issues and the propagation tests alone would still pass.

## Verification

validup 467 → 471 tests. All five suites green, `tsc --noEmit` clean per package, `eslint` clean.