### PR TITLE
chore(standard-schema): typecheck specs, and release at 1.0.0

### DIFF
--- a/packages/standard-schema/package.json
+++ b/packages/standard-schema/package.json
@@ -31,6 +31,7 @@
         "build:types": "tsc --noEmit -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "npm run build:types && npm run build:js",
+        "test:types": "tsc --noEmit",
         "test": "vitest --config test/vitest.config.ts --run",
         "test:coverage": "vitest --config test/vitest.config.ts --run --coverage"
     },

--- a/packages/standard-schema/tsconfig.json
+++ b/packages/standard-schema/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../../tsconfig.json",
     "include": [
-        "src/**/*"
+        "src/**/*",
+        "test/**/*.ts"
     ]
 }


### PR DESCRIPTION
Fixes `@validup/standard-schema` being left at **0.2.4** while the other four packages go to **1.0.0** in #412 — without hand-editing any version or dependency range.

## Why it was left behind

`release-as: "1.0.0"` only applies to components release-please treats as **release candidates** — ones with at least one *releasable* conventional commit since their last tag.

This package's only change since 0.2.3 was #446, a `test:` commit — a hidden type. So it was never a candidate. The `node-workspace` plugin pulled it into the release *afterwards*, purely because its `validup` peer changed, and that synthesized entry takes a **patch** bump and never consults `release-as`.

It shows in the proposed changelog: standard-schema's entry has *only* a `Dependencies` section, where every other package has real `Features` / `Bug Fixes`.

## The fix: `Release-As`, not a manual bump

`Release-As: 1.0.0` is release-please's documented mechanism for this, and it works from a non-releasable commit type — the upstream example is literally `chore:` + an empty commit. Version numbers and peer ranges stay owned by release-please.

## Correcting my first attempt

The initial version of this PR set `packages/standard-schema/package.json`'s peer to `validup: ^1.0.0` directly. **That was wrong and CI caught it:**

```
npm error code ETARGET
npm error notarget No matching version found for validup@^1.0.0.
```

`validup@1.0.0` is not published yet and the workspace copy is still 0.5.1, so `npm ci` cannot resolve the range. The peer bump can only land *inside* the release PR, where it happens alongside validup's own version bump — which the `node-workspace` plugin already handles. That edit is reverted; this PR touches no version and no dependency range.

## The substantive change

`tsconfig.json` included only `src/**/*`, so **nothing ever typechecked `test/`**. This adds `test/**/*.ts` plus a `test:types` script, matching `@validup/validator-js`. `tsconfig.build.json` is untouched, so specs still never influence the published `.d.mts`.

That was the open follow-up recorded in `.agents/testing.md`, which predicted this package would "pass as-is" — it does, cleanly.

## After merging

release-please refreshes #412; standard-schema should move from 0.2.4 to **1.0.0**. Worth checking that row before merging #412 — that merge is what publishes to npm.

## Verification

16 tests green, `npm run test:types` clean, `eslint` clean.